### PR TITLE
v1.0.0-beta.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
-    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.1"
+    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.2"
 
     testImplementation 'junit:junit:4.12'
 

--- a/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingJavaExampleActivity.java
@@ -40,6 +40,11 @@ public class ForwardGeocodingJavaExampleActivity extends AppCompatActivity {
         }
 
         @Override
+        public void onCategoryResult(@NonNull List<? extends SearchResult> results) {
+            Log.i("SearchApiExample", "Category search results: " + results);
+        }
+
+        @Override
         public void onError(@NonNull Exception e) {
             Log.i("SearchApiExample", "Search error: ", e);
         }

--- a/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingKotlinExampleActivity.kt
@@ -31,6 +31,10 @@ class ForwardGeocodingKotlinExampleActivity : Activity() {
             Log.i("SearchApiExample", "Search result: $result")
         }
 
+        override fun onCategoryResult(results: List<SearchResult>) {
+            Log.i("SearchApiExample", "Category search results: $results")
+        }
+
         override fun onError(e: Exception) {
             Log.i("SearchApiExample", "Search error", e)
         }


### PR DESCRIPTION
## v1.0.0-beta.2

### Breaking changes
- [CORE] Parameter `endpointBaseUrl` of the `MapboxSearchSdk.initialize()` method has been renamed to `geocodingEndpointBaseUrl`. In addition, new parameter named `singleBoxSearchBaseUrl` has been added to specify `Single Box Search` API endpoint.
- [CORE] Enum `SearchResultType` now has two more types - `PLACE` and `STREET`.
- [CORE] `SearchSuggestion.TypeDescription` has been transformed to a new type called `SearchSuggestionType`. See documentation of `SearchSuggestionType` for more details. Also property `typeDescription` of the `SearchSuggestion` type has been renamed to `type`.
- [CORE] `SearchCategorySuggestion` type has been removed. Use `SearchSuggestion.type` to check if a suggestion is a category.
- [CORE] `SearchSelectionCallback.onCategoryResult(results: List<SearchResult>)` callback has been added.
- [UI] From `SearchBottomSheetView`, `SearchPlaceBottomSheetView`, `SearchCategoriesBottomSheetView` classes removed functions that were available to simplify interaction with Kotlin functional interfaces.
With Kotlin 1.4.0 [SAM conversions for Kotlin interfaces](https://kotlinlang.org/docs/reference/whatsnew14.html#sam-conversions-for-kotlin-interfaces) are available and these functions are not needed anymore.
Removing these functions from the SDK may bring breaking changes if you were accessing those functions from Java code (which is usually pointless) or if you are using older versions of Kotlin.

### New features
- [ALL] Support of the new search backend (will be announced soon).
- [ALL] Bump Kotlin version to 1.4.0.

### Bug fixes
We are bug-free :wink: (almost).
