### PR TITLE
Search SDK 1.0.0-beta.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
-    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.3"
+    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.4"
 
     implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.5.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,13 +44,13 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.1'
+    implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.4"
 
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.5.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0'
 
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/java/com/mapbox/search/demo/api/CategorySearchKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/demo/api/CategorySearchKotlinExampleActivity.kt
@@ -21,7 +21,7 @@ class CategorySearchKotlinExampleActivity : AppCompatActivity() {
             if (results.isEmpty()) {
                 Log.i("SearchApiExample", "No category search results")
             } else {
-                Log.i("SearchApiExample", "Category search results: ${results.first()}")
+                Log.i("SearchApiExample", "Category search results: $results")
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-    ext.kotlin_version = "1.4.0"
+    ext.kotlin_version = "1.4.21"
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.1"
+        classpath "com.android.tools.build:gradle:4.0.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
## v1.0.0-beta.4

### Breaking changes
- [CORE] New `SearchSuggestionType` subtype has been added, which may break existing code in some cases.
- [CORE] `proximity`, `origin` and `navProfile` properties have been removed from `RequestOptions`.
- [CORE] `SearchResultMetadata`'s API has been significantly changed.
    - Function `SearchResultMetadata.getAllData()` has been removed. Instead `extraData` property is available. This property provides the data that is not available via the other properties of the class.
    - Constants `KEY_PHONE`, `KEY_WEBSITE`, `KEY_REVIEW_COUNT`, `KEY_AVERAGE_RATING` were removed. Instead, use `phone`, `website`, `reviewCount`, `averageRating` properties directly.

### New features
- [CORE] New `SearchSuggestionType` subtype has been added. Now `SearchSuggestion` can have `Query` type, which means that selection of this suggestion type will result in new suggestions.
- [CORE] Now you can search along a route, pass `RouteOptions` to `SearchOptions` to configure route parameters.
- [CORE] Now `SearchResultMetadata` provides associated with search result photos and also provides a new `description` property.
- [CORE] Now `SearchSuggestion` has an optional `address` property.
- [CORE] Now `RequestOptions` has new `options` property and additional `proximityRewritten` and `originRewritten` flags that denote whether `options` have been modified by the Search SDK.

### Bug fixes
- [CORE] Fixed a bug that happened when backend sent suggestion with `POSTCODE` type.
- [UI] Now UI SDK always shows address if it's available.