### PR TITLE
Search SDK Beta.8.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         buildConfigField "String", "MAPBOX_API_TOKEN", "\"$mapboxApiToken\""
 
         applicationId "com.mapbox.search.demo"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"
@@ -48,7 +48,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.7"
+    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.8"
 
     implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0'


### PR DESCRIPTION
## v1.0.0-beta.8

### Breaking changes
- [CORE, UI] Minimum Android SDK version 21, OkHttp 4.9.0.
- [CORE] `SearchResultType` enum types order have been changed. Now all types are sorted in descending order by the size of the associated geofeature.

### Bug fixes
- [CORE] Fixed a bug with `SearchSuggestionType.Category()` where property `canonicalName` was incorrect.
- [UI] Functions `findByName()` and `findBySBSName()` from `Category` class now work properly: `findByName()` finds categories for names associated with Geocoding endpoint, `findBySBSName()` - for names associated with SBS endpoints.