### PR TITLE
Search SDK v1.0.0-beta.11, Kotlin Parcelize plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
 def mapboxApiToken = project.properties['MAPBOX_ACCESS_TOKEN'] ?: System.getenv('MAPBOX_ACCESS_TOKEN')
 if (mapboxApiToken == null) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.10"
+    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.11"
 
     implementation "com.mapbox.maps:android:10.0.0-beta.16"
 

--- a/app/src/main/java/com/mapbox/search/demo/SearchViewBottomSheetsMediator.kt
+++ b/app/src/main/java/com/mapbox/search/demo/SearchViewBottomSheetsMediator.kt
@@ -7,7 +7,7 @@ import com.mapbox.search.ui.view.category.Category
 import com.mapbox.search.ui.view.category.SearchCategoriesBottomSheetView
 import com.mapbox.search.ui.view.place.SearchPlace
 import com.mapbox.search.ui.view.place.SearchPlaceBottomSheetView
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.LinkedList
 import java.util.concurrent.CopyOnWriteArrayList
 

--- a/app/src/main/java/com/mapbox/search/demo/SearchViewBottomSheetsMediator.kt
+++ b/app/src/main/java/com/mapbox/search/demo/SearchViewBottomSheetsMediator.kt
@@ -131,23 +131,27 @@ class SearchViewBottomSheetsMediator(
             if (transaction == null) {
                 fallback { "Transaction is null" }
             } else {
-                when (transaction.screen) {
-                    Screen.CATEGORIES -> {
-                        val category = (transaction.arg as? Bundle)?.unwrapCategory()
-                        if (category == null) {
-                            fallback { "Saved category is null" }
-                        } else {
-                            openCategory(category, fromBackStack = true)
-                        }
-                    }
-                    Screen.PLACE -> {
-                        val place = transaction.arg as? SearchPlace
-                        if (place == null) {
-                            fallback { "Saved place is null" }
-                        } else {
-                            openPlaceCard(place, fromBackStack = true)
-                        }
-                    }
+                transaction.execute()
+            }
+        }
+    }
+
+    private fun Transaction.execute() {
+        when (screen) {
+            Screen.CATEGORIES -> {
+                val category = (arg as? Bundle)?.unwrapCategory()
+                if (category == null) {
+                    fallback { "Saved category is null" }
+                } else {
+                    openCategory(category, fromBackStack = true)
+                }
+            }
+            Screen.PLACE -> {
+                val place = arg as? SearchPlace
+                if (place == null) {
+                    fallback { "Saved place is null" }
+                } else {
+                    openPlaceCard(place, fromBackStack = true)
                 }
             }
         }

--- a/app/src/main/java/com/mapbox/search/demo/api/CategorySearchJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/demo/api/CategorySearchJavaExampleActivity.java
@@ -12,7 +12,6 @@ import com.mapbox.search.CategorySearchOptions;
 import com.mapbox.search.MapboxSearchSdk;
 import com.mapbox.search.ResponseInfo;
 import com.mapbox.search.SearchCallback;
-import com.mapbox.search.SearchOptions;
 import com.mapbox.search.SearchRequestTask;
 import com.mapbox.search.result.SearchResult;
 

--- a/app/src/main/java/com/mapbox/search/demo/api/CategorySearchKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/demo/api/CategorySearchKotlinExampleActivity.kt
@@ -8,7 +8,6 @@ import com.mapbox.search.CategorySearchOptions
 import com.mapbox.search.MapboxSearchSdk
 import com.mapbox.search.ResponseInfo
 import com.mapbox.search.SearchCallback
-import com.mapbox.search.SearchOptions
 import com.mapbox.search.SearchRequestTask
 import com.mapbox.search.result.SearchResult
 

--- a/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingBatchResolvingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingBatchResolvingJavaExampleActivity.java
@@ -27,10 +27,7 @@ public class ForwardGeocodingBatchResolvingJavaExampleActivity extends AppCompat
     private final SearchSelectionCallback searchCallback = new SearchSelectionCallback() {
 
         @Override
-        public void onSuggestions(
-            @NonNull List<? extends SearchSuggestion> suggestions,
-            @NonNull ResponseInfo responseInfo
-        ) {
+        public void onSuggestions(@NonNull List<? extends SearchSuggestion> suggestions, @NonNull ResponseInfo responseInfo) {
             if (suggestions.isEmpty()) {
                 Log.i("SearchApiExample", "No suggestions found");
             } else {
@@ -40,20 +37,12 @@ public class ForwardGeocodingBatchResolvingJavaExampleActivity extends AppCompat
         }
 
         @Override
-        public void onResult(
-            @NonNull SearchSuggestion suggestion,
-            @NonNull SearchResult result,
-            @NonNull ResponseInfo responseInfo
-        ) {
+        public void onResult(@NonNull SearchSuggestion suggestion, @NonNull SearchResult result, @NonNull ResponseInfo info) {
             Log.i("SearchApiExample", "Search result: " + result);
         }
 
         @Override
-        public void onCategoryResult(
-            @NonNull SearchSuggestion suggestion,
-            @NonNull List<? extends SearchResult> results,
-            @NonNull ResponseInfo responseInfo
-        ) {
+        public void onCategoryResult(@NonNull SearchSuggestion suggestion, @NonNull List<? extends SearchResult> results, @NonNull ResponseInfo responseInfo) {
             Log.i("SearchApiExample", "Category search results: " + results);
         }
 
@@ -66,11 +55,7 @@ public class ForwardGeocodingBatchResolvingJavaExampleActivity extends AppCompat
     private final SearchMultipleSelectionCallback multipleSelection = new SearchMultipleSelectionCallback() {
 
         @Override
-        public void onResult(
-            @NonNull List<? extends SearchSuggestion> suggestions,
-            @NonNull List<? extends SearchResult> results,
-            @NonNull ResponseInfo responseInfo
-        ) {
+        public void onResult(@NonNull List<? extends SearchSuggestion> suggestions, @NonNull List<? extends SearchResult> results, @NonNull ResponseInfo responseInfo) {
             Log.i("SearchApiExample", "Batch retrieve results: " + results);
         }
 

--- a/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingBatchResolvingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingBatchResolvingKotlinExampleActivity.kt
@@ -29,7 +29,11 @@ class ForwardGeocodingBatchResolvingKotlinExampleActivity : Activity() {
             }
         }
 
-        override fun onResult(suggestion: SearchSuggestion, result: SearchResult, responseInfo: ResponseInfo) {
+        override fun onResult(
+            suggestion: SearchSuggestion,
+            result: SearchResult,
+            responseInfo: ResponseInfo
+        ) {
             Log.i("SearchApiExample", "Search result: $result")
         }
 

--- a/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingJavaExampleActivity.java
@@ -26,10 +26,7 @@ public class ForwardGeocodingJavaExampleActivity extends AppCompatActivity {
     private final SearchSelectionCallback searchCallback = new SearchSelectionCallback() {
 
         @Override
-        public void onSuggestions(
-            @NonNull List<? extends SearchSuggestion> suggestions,
-            @NonNull ResponseInfo responseInfo
-        ) {
+        public void onSuggestions(@NonNull List<? extends SearchSuggestion> suggestions, @NonNull ResponseInfo responseInfo) {
             if (suggestions.isEmpty()) {
                 Log.i("SearchApiExample", "No suggestions found");
             } else {
@@ -39,20 +36,12 @@ public class ForwardGeocodingJavaExampleActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onResult(
-            @NonNull SearchSuggestion searchSuggestion,
-            @NonNull SearchResult result,
-            @NonNull ResponseInfo responseInfo
-        ) {
+        public void onResult(@NonNull SearchSuggestion suggestion, @NonNull SearchResult result, @NonNull ResponseInfo info) {
             Log.i("SearchApiExample", "Search result: " + result);
         }
 
         @Override
-        public void onCategoryResult(
-            @NonNull SearchSuggestion searchSuggestion,
-            @NonNull List<? extends SearchResult> results,
-            @NonNull ResponseInfo responseInfo
-        ) {
+        public void onCategoryResult(@NonNull SearchSuggestion suggestion, @NonNull List<? extends SearchResult> results, @NonNull ResponseInfo responseInfo) {
             Log.i("SearchApiExample", "Category search results: " + results);
         }
 

--- a/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/demo/api/ForwardGeocodingKotlinExampleActivity.kt
@@ -28,11 +28,19 @@ class ForwardGeocodingKotlinExampleActivity : Activity() {
             }
         }
 
-        override fun onResult(suggestion: SearchSuggestion, result: SearchResult, responseInfo: ResponseInfo) {
+        override fun onResult(
+            suggestion: SearchSuggestion,
+            result: SearchResult,
+            responseInfo: ResponseInfo
+        ) {
             Log.i("SearchApiExample", "Search result: $result")
         }
 
-        override fun onCategoryResult(suggestion: SearchSuggestion, results: List<SearchResult>, responseInfo: ResponseInfo) {
+        override fun onCategoryResult(
+            suggestion: SearchSuggestion,
+            results: List<SearchResult>,
+            responseInfo: ResponseInfo
+        ) {
             Log.i("SearchApiExample", "Category search results: $results")
         }
 

--- a/app/src/main/java/com/mapbox/search/demo/maps/MapsIntegrationExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/demo/maps/MapsIntegrationExampleActivity.kt
@@ -30,6 +30,7 @@ import com.mapbox.maps.extension.style.sources.getSourceAs
 import com.mapbox.maps.extension.style.style
 import com.mapbox.search.demo.R
 import com.mapbox.search.demo.SearchViewBottomSheetsMediator
+import com.mapbox.search.demo.SearchViewBottomSheetsMediator.SearchBottomSheetsEventsListener
 import com.mapbox.search.result.SearchResult
 import com.mapbox.search.ui.view.SearchBottomSheetView
 import com.mapbox.search.ui.view.category.Category
@@ -102,7 +103,7 @@ class MapsIntegrationExampleActivity : AppCompatActivity() {
             cardsMediator.onRestoreInstanceState(it)
         }
 
-        cardsMediator.addSearchBottomSheetsEventsListener(object : SearchViewBottomSheetsMediator.SearchBottomSheetsEventsListener {
+        cardsMediator.addSearchBottomSheetsEventsListener(object : SearchBottomSheetsEventsListener {
             override fun onOpenPlaceBottomSheet(place: SearchPlace) {
                 showMarker(place.coordinate)
             }


### PR DESCRIPTION
## v1.0.0-beta.11

### Breaking changes
- [CORE] The following methods now require extra `responseInfo: ResponseInfo` parameter:
    - `AnalyticsService.createRawFeedbackEvent(searchResult: SearchResult)`
    - `AnalyticsService.createRawFeedbackEvent(searchSuggestion: SearchSuggestion)`
    - `AnalyticsService.sendFeedback(searchResult: SearchResult)`
    - `AnalyticsService.sendFeedback(searchSuggestion: SearchSuggestion)`

### New features
- [CORE] `FeedbackEvent.FeedbackReason` annotation class has been added which helps us to enforce developers to use one of predefined constants for `FeedbackEvent.reason` property. Currently available constants are:
    - `FeedbackReason.INCORRECT_NAME`
    - `FeedbackReason.INCORRECT_ADDRESS`
    - `FeedbackReason.INCORRECT_LOCATION`
    - `FeedbackReason.OTHER`

