### PR TITLE
Search SDK v1.0.0-beta.15

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,8 +49,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.14"
-    implementation "com.mapbox.maps:android:10.0.0-beta.19"
+    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.15"
+    implementation "com.mapbox.maps:android:10.0.0-rc.3"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
@@ -91,6 +91,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Process bottom sheets events
+        @Suppress("EmptyFunctionBlock")
         cardsMediator.addSearchBottomSheetsEventsListener(object : SearchViewBottomSheetsMediator.SearchBottomSheetsEventsListener {
             override fun onOpenPlaceBottomSheet(place: SearchPlace) {}
 

--- a/app/src/main/java/com/mapbox/search/sample/api/FavoritesDataProviderJavaExample.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/FavoritesDataProviderJavaExample.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.geojson.Point;
+import com.mapbox.search.AsyncOperationTask;
 import com.mapbox.search.MapboxSearchSdk;
 import com.mapbox.search.record.FavoriteRecord;
 import com.mapbox.search.record.FavoritesDataProvider;
@@ -27,7 +28,7 @@ public class FavoritesDataProviderJavaExample extends AppCompatActivity {
 
     private final FavoritesDataProvider favoritesDataProvider = MapboxSearchSdk.getServiceProvider().favoritesDataProvider();
 
-    private Future<?> futureTask = null;
+    private AsyncOperationTask task = null;
 
     private final CompletionCallback<List<FavoriteRecord>> retrieveFavoritesCallback = new CompletionCallback<List<FavoriteRecord>>() {
         @Override
@@ -45,7 +46,7 @@ public class FavoritesDataProviderJavaExample extends AppCompatActivity {
         @Override
         public void onComplete(Unit result) {
             Log.i("SearchApiExample", "Favorite record added");
-            futureTask = favoritesDataProvider.getAll(retrieveFavoritesCallback);
+            task = favoritesDataProvider.getAll(retrieveFavoritesCallback);
         }
 
         @Override
@@ -77,13 +78,13 @@ public class FavoritesDataProviderJavaExample extends AppCompatActivity {
             null
         );
 
-        futureTask = favoritesDataProvider.add(newFavorite, addFavoriteCallback);
+        task = favoritesDataProvider.add(newFavorite, addFavoriteCallback);
     }
 
     @Override
     protected void onDestroy() {
         favoritesDataProvider.removeOnDataChangedListener(onDataChangedListener);
-        futureTask.cancel(true);
+        task.cancel();
         super.onDestroy();
     }
 }

--- a/app/src/main/java/com/mapbox/search/sample/api/FavoritesDataProviderKotlinExample.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/FavoritesDataProviderKotlinExample.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.geojson.Point
+import com.mapbox.search.AsyncOperationTask
 import com.mapbox.search.MapboxSearchSdk.serviceProvider
 import com.mapbox.search.record.FavoriteRecord
 import com.mapbox.search.record.IndexableDataProvider.CompletionCallback
@@ -11,13 +12,12 @@ import com.mapbox.search.record.LocalDataProvider.OnDataChangedListener
 import com.mapbox.search.result.SearchAddress
 import com.mapbox.search.result.SearchResultType
 import java.util.UUID
-import java.util.concurrent.Future
 
 class FavoritesDataProviderKotlinExample : AppCompatActivity() {
 
     private val favoritesDataProvider = serviceProvider.favoritesDataProvider()
 
-    private lateinit var futureTask: Future<*>
+    private lateinit var task: AsyncOperationTask
 
     private val retrieveFavoritesCallback: CompletionCallback<List<FavoriteRecord>> =
         object : CompletionCallback<List<FavoriteRecord>> {
@@ -33,7 +33,7 @@ class FavoritesDataProviderKotlinExample : AppCompatActivity() {
     private val addFavoriteCallback: CompletionCallback<Unit> = object : CompletionCallback<Unit> {
         override fun onComplete(result: Unit) {
             Log.i("SearchApiExample", "Favorite record added")
-            futureTask = favoritesDataProvider.getAll(retrieveFavoritesCallback)
+            task = favoritesDataProvider.getAll(retrieveFavoritesCallback)
         }
 
         override fun onError(e: Exception) {
@@ -66,12 +66,12 @@ class FavoritesDataProviderKotlinExample : AppCompatActivity() {
             metadata = null
         )
 
-        futureTask = favoritesDataProvider.add(newFavorite, addFavoriteCallback)
+        task = favoritesDataProvider.add(newFavorite, addFavoriteCallback)
     }
 
     override fun onDestroy() {
         favoritesDataProvider.removeOnDataChangedListener(onDataChangedListener)
-        futureTask.cancel(true)
+        task.cancel()
         super.onDestroy()
     }
 }

--- a/app/src/main/java/com/mapbox/search/sample/api/HistoryDataProviderJavaExample.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/HistoryDataProviderJavaExample.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.mapbox.search.AsyncOperationTask;
 import com.mapbox.search.MapboxSearchSdk;
 import com.mapbox.search.record.HistoryDataProvider;
 import com.mapbox.search.record.HistoryRecord;
@@ -14,13 +15,12 @@ import com.mapbox.search.record.IndexableDataProvider.CompletionCallback;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.concurrent.Future;
 
 public class HistoryDataProviderJavaExample extends AppCompatActivity {
 
     private final HistoryDataProvider historyDataProvider = MapboxSearchSdk.getServiceProvider().historyDataProvider();
 
-    private Future<List<HistoryRecord>> retrieveTask = null;
+    private AsyncOperationTask task = null;
 
     private final CompletionCallback<List<HistoryRecord>> callback = new CompletionCallback<List<HistoryRecord>>() {
         @Override
@@ -37,12 +37,12 @@ public class HistoryDataProviderJavaExample extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        retrieveTask = historyDataProvider.getAll(callback);
+        task = historyDataProvider.getAll(callback);
     }
 
     @Override
     protected void onDestroy() {
-        retrieveTask.cancel(true);
+        task.cancel();
         super.onDestroy();
     }
 }

--- a/app/src/main/java/com/mapbox/search/sample/api/HistoryDataProviderKotlinExample.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/HistoryDataProviderKotlinExample.kt
@@ -3,16 +3,16 @@ package com.mapbox.search.sample.api
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.search.AsyncOperationTask
 import com.mapbox.search.MapboxSearchSdk.serviceProvider
 import com.mapbox.search.record.HistoryRecord
 import com.mapbox.search.record.IndexableDataProvider.CompletionCallback
-import java.util.concurrent.Future
 
 class HistoryDataProviderKotlinExample : AppCompatActivity() {
 
     private val historyDataProvider = serviceProvider.historyDataProvider()
 
-    private lateinit var retrieveTask: Future<List<HistoryRecord>>
+    private lateinit var task: AsyncOperationTask
 
     private val callback: CompletionCallback<List<HistoryRecord>> = object : CompletionCallback<List<HistoryRecord>> {
         override fun onComplete(result: List<HistoryRecord>) {
@@ -26,11 +26,11 @@ class HistoryDataProviderKotlinExample : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        retrieveTask = historyDataProvider.getAll(callback)
+        task = historyDataProvider.getAll(callback)
     }
 
     override fun onDestroy() {
-        retrieveTask.cancel(true)
+        task.cancel()
         super.onDestroy()
     }
 }


### PR DESCRIPTION
## v1.0.0-beta.15

### Breaking changes
- [CORE] Async functions in `IndexableDataProvider` and `OfflineSearchEngine.addOfflineRegion()` now return `AsyncOperationTask` object instead of `Future`. 
- [CORE] Function `DistanceCalculator.squareDistance()` has been removed.
- [UI] Property `SearchBottomSheetView.Configuration.searchOptions` and corresponding `Configuration.Builder` function have been removed. Now you can provide `SearchOptions` through `SearchBottomSheetView.searchOptions` and override them for each new request.
- [UI] New `distanceMeters` property has been added to `SearchPlace`. Therefore, `copy()`, `createFromSearchResult()` and `createFromIndexableRecord()` methods and `SearchPlace` constructor accept `distanceMeters` parameter now.

### New features
- [CORE] New `distanceMeters` property has been added to `SearchResult`.
- [CORE] Now `SearchOptions.indexableRecordsDistanceThresholdMeters` and `CategorySearchOptions.indexableRecordsDistanceThresholdMeters` options are available that allow to look up for indexable records only within specified distance threshold.
- [UI] Now user can edit name and can delete favorite, created from template (e.g. Work template).
- [UI] Now you can provide `CategorySearchOptions` that will be used for search request in `SearchCategoriesBottomSheetView`. Options can be provided via `fun open(category: Category, searchOptions: CategorySearchOptions)`.
- [UI] New `updateDistance()` method has been added to `SearchPlaceBottomSheetView`.

### Bug fixes
- [CORE] Fixed a bug with uninitialized in some cases `SearchResultMetadata` properties.

### Mapbox dependencies
- Common SDK `14.2.0`
- Telemetry SDK `8.1.0`