### PR TITLE
Search SDK 1.0.0-beta.16

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,8 +49,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.15"
-    implementation "com.mapbox.maps:android:10.0.0-rc.3"
+    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.16"
+    implementation "com.mapbox.maps:android:10.0.0-rc.4"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/src/main/java/com/mapbox/search/sample/SearchViewBottomSheetsMediator.kt
+++ b/app/src/main/java/com/mapbox/search/sample/SearchViewBottomSheetsMediator.kt
@@ -103,7 +103,7 @@ class SearchViewBottomSheetsMediator(
         if (fromBackStack) {
             categoriesBottomSheetView.restorePreviousNonHiddenState(category)
         } else {
-            screensStack.push(Transaction(Screen.CATEGORIES, wrapCategory(category)))
+            screensStack.push(Transaction(Screen.CATEGORIES, category))
             categoriesBottomSheetView.open(category)
         }
         searchBottomSheetView.hide()
@@ -167,7 +167,7 @@ class SearchViewBottomSheetsMediator(
     private fun Transaction.execute() {
         when (screen) {
             Screen.CATEGORIES -> {
-                val category = (arg as? Bundle)?.unwrapCategory()
+                val category = arg as? Category
                 if (category == null) {
                     fallback { "Saved category is null" }
                 } else {
@@ -223,18 +223,6 @@ class SearchViewBottomSheetsMediator(
     private companion object {
 
         const val KEY_STATE_EXTERNAL_BACK_STACK = "SearchViewBottomSheetsMediator.state.external.back_stack"
-
-        const val KEY_CATEGORY = "SearchViewBottomSheetsMediator.key.category"
-
-        fun wrapCategory(category: Category): Bundle {
-            return Bundle().apply {
-                putParcelable(KEY_CATEGORY, category)
-            }
-        }
-
-        fun Bundle?.unwrapCategory(): Category? {
-            return this?.getParcelable(KEY_CATEGORY)
-        }
 
         fun userDistanceTo(destination: Point): Double? {
             val currentLocation = MapboxSearchSdk.serviceProvider.locationProvider().getLocation()


### PR DESCRIPTION
## v1.0.0-beta.16

### Breaking changes
- [UI] Functions `Category.findBySBSName()` and `Category.findByName()` have been removed, now you can use `Category.findByCanonicalName()` which looks up for a Category by any of SBS or geocoding canonical names.

### New features
- [UI] Now `com.mapbox.search.ui.view.category.Category`'s constructor and properties are public, you can instantiate a new category to be used in the UI Search SDK.
- [UI] Expose `maxWidth` layout parameter for `SearchSdkFrameLayout` class and its subclasses in public API.

### Mapbox dependencies
- Common SDK `16.0.0`
- Telemetry SDK `8.1.0`
