### PR TITLE
Search SDK v1.0.0-beta.17

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.16"
+    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.17"
     implementation "com.mapbox.maps:android:10.0.0-rc.4"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,6 @@ if (mapboxApiToken == null) {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.3"
 
     defaultConfig {
         buildConfigField "String", "MAPBOX_API_TOKEN", "\"$mapboxApiToken\""
@@ -45,13 +44,13 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.5.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
 
     implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.17"
-    implementation "com.mapbox.maps:android:10.0.0-rc.4"
+    implementation "com.mapbox.maps:android:10.0.0-rc.5"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@ buildscript {
     ext.kotlin_version = "1.4.30"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -18,7 +18,7 @@ if (sdkRegistryToken == null) {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
 
         maven {
             url 'https://api.mapbox.com/downloads/v2/releases/maven'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
## v1.0.0-beta.17

### Breaking changes
- [CORE] `MapboxSearchSdk.initialize()` function's signature has been changed: `geocodingEndpointBaseUrl` and `singleBoxSearchBaseUrl` parameters have been removed and new parameter `searchSdkSettings: SearchSdkSettings` has been added. With new `SearchSdkSettings` class user can specify not only search endpoints, but also maximum allowed `HistoryRecords` amount in `HistoryDataProvider`.
- [CORE] `SearchSuggestionType.IndexableRecordItem`'s constructor has been changed: new parameter `type: SearchResultType` has been added. Now user can get the type of resolved `IndexableRecord` before the selection of `SearchSuggestion`, associated with given `IndexableRecordItem`.
- [CORE] `SearchSuggestionType.SearchResultSuggestion`, `SearchSuggestionType.Category` and `SearchSuggestionType.IndexableRecordItem` constructors visibility have been reduced to `internal`.

### New features
- [CORE] `MainThreadWorker` and `SearchSdkMainThreadWorker` classes are now public, they can be used to override main thread job handler which can be useful for testing.
- [UI] Now history records matched with saved favorites will be marked as favorites in the search history view.

### Bug fixes
- [UI] Fix for suggestion clicks processing.

### Mapbox dependencies
- Common SDK `16.2.0`
- Telemetry SDK `8.1.0`