### PR TITLE
[mapbox-search-android] `v1.0.0-beta.18`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
+apply plugin: 'kotlin-kapt'
 
 def mapboxApiToken = project.properties['MAPBOX_ACCESS_TOKEN'] ?: System.getenv('MAPBOX_ACCESS_TOKEN')
 if (mapboxApiToken == null) {
@@ -48,8 +49,18 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
 
-    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.18"
-    implementation "com.mapbox.maps:android:10.0.0-rc.5"
+    // Loader module is excluded just for custom library loader example.
+    // Don't exclude it if you are good with a default loader.
+    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.18") {
+        exclude group: "com.mapbox.common", module: "loader"
+    }
+    implementation ("com.mapbox.maps:android:10.0.0-rc.5") {
+        exclude group: "com.mapbox.common", module: "loader"
+    }
+
+    // Needed just for custom library loader example.
+    compileOnly "com.mapbox.base:annotations:0.5.0"
+    kapt "com.mapbox.base:annotations-processor:0.5.0"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
 
-    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.17"
+    implementation "com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.18"
     implementation "com.mapbox.maps:android:10.0.0-rc.5"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/java/com/mapbox/search/sample/MyLibraryLoader.kt
+++ b/app/src/main/java/com/mapbox/search/sample/MyLibraryLoader.kt
@@ -1,0 +1,14 @@
+package com.mapbox.search.sample
+
+import android.util.Log
+import com.mapbox.annotation.module.MapboxModule
+import com.mapbox.annotation.module.MapboxModuleType
+import com.mapbox.common.module.LibraryLoader
+
+@MapboxModule(MapboxModuleType.CommonLibraryLoader)
+class MyLibraryLoader : LibraryLoader {
+    override fun load(libraryName: String) {
+        Log.i("SearchApiExample", "Load native library: $libraryName")
+        System.loadLibrary(libraryName)
+    }
+}

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingJavaExampleActivity.java
@@ -50,8 +50,8 @@ public class OfflineReverseGeocodingJavaExampleActivity extends AppCompatActivit
          */
         searchEngine.addOfflineRegion(
             new File(getFilesDir(), "offline_data/germany").getPath(),
-            Collections.singletonList("germany.map"),
-            "germany.boundary",
+            Collections.singletonList("germany.map.cont"),
+            "germany.boundary.cont",
             new OfflineSearchEngine.AddRegionCallback() {
                 @Override
                 public void onAdded() {

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingKotlinExampleActivity.kt
@@ -41,8 +41,8 @@ class OfflineReverseGeocodingKotlinExampleActivity : Activity() {
          */
         searchEngine.addOfflineRegion(
             path = File(filesDir, "offline_data/germany").path,
-            mapsFileNames = listOf("germany.map"),
-            boundaryFileName = "germany.boundary",
+            mapsFileNames = listOf("germany.map.cont"),
+            boundaryFileName = "germany.boundary.cont",
             callback = object : AddRegionCallback {
                 override fun onAdded() {
                     Log.i("SearchApiExample", "Offline region has been added")

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
@@ -65,8 +65,8 @@ public class OfflineSearchJavaExampleActivity extends AppCompatActivity {
          */
         searchEngine.addOfflineRegion(
             new File(getFilesDir(), "offline_data/germany").getPath(),
-            Collections.singletonList("germany.map"),
-            "germany.boundary",
+            Collections.singletonList("germany.map.cont"),
+            "germany.boundary.cont",
             new OfflineSearchEngine.AddRegionCallback() {
                 @Override
                 public void onAdded() {

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
@@ -61,8 +61,8 @@ class OfflineSearchKotlinExampleActivity : Activity() {
          */
         searchEngine.addOfflineRegion(
             path = File(filesDir, "offline_data/germany").path,
-            mapsFileNames = listOf("germany.map"),
-            boundaryFileName = "germany.boundary",
+            mapsFileNames = listOf("germany.map.cont"),
+            boundaryFileName = "germany.boundary.cont",
             callback = object : OfflineSearchEngine.AddRegionCallback {
                 override fun onAdded() {
                     Log.i("SearchApiExample", "Offline region has been added")


### PR DESCRIPTION
## 1.0.0-beta.18

### Breaking changes
- [CORE] Now `OfflineSearchEngine.addOfflineRegion()` doesn't implicitly add `.cont` extensions for offline data files.

### New features
- [CORE] Now customers can override native library loader. See [Mapbox Android Modularization](https://github.com/mapbox/mapbox-base-android/blob/master/MODULARIZATION.md) for more information.

### Mapbox dependencies
- Common SDK `17.0.0`
- Telemetry SDK `8.1.0`

Note that `MapsIntegrationExampleActivity` is broken, need Maps SDK update.