### PR TITLE
Search SDK v1.0.0-beta.19

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ if (mapboxApiToken == null) {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         buildConfigField "String", "MAPBOX_API_TOKEN", "\"$mapboxApiToken\""
@@ -17,7 +17,7 @@ android {
 
         applicationId "com.mapbox.search.demo"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -51,10 +51,10 @@ dependencies {
 
     // Loader module is excluded just for custom library loader example.
     // Don't exclude it if you are good with a default loader.
-    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.18") {
+    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.19") {
         exclude group: "com.mapbox.common", module: "loader"
     }
-    implementation ("com.mapbox.maps:android:10.0.0-rc.5") {
+    implementation ("com.mapbox.maps:android:10.0.0-rc.8") {
         exclude group: "com.mapbox.common", module: "loader"
     }
 

--- a/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
@@ -17,6 +17,8 @@ import androidx.core.content.ContextCompat
 import com.mapbox.search.result.SearchResult
 import com.mapbox.search.sample.api.CategorySearchJavaExampleActivity
 import com.mapbox.search.sample.api.CategorySearchKotlinExampleActivity
+import com.mapbox.search.sample.api.CustomIndexableDataProviderJavaExample
+import com.mapbox.search.sample.api.CustomIndexableDataProviderKotlinExample
 import com.mapbox.search.sample.api.FavoritesDataProviderJavaExample
 import com.mapbox.search.sample.api.FavoritesDataProviderKotlinExample
 import com.mapbox.search.sample.api.ForwardGeocodingBatchResolvingJavaExampleActivity
@@ -146,6 +148,14 @@ class MainActivity : AppCompatActivity() {
         return when (item.itemId) {
             R.id.open_simple_ui -> {
                 startActivity(Intent(this, SimpleUiSearchActivity::class.java))
+                true
+            }
+            R.id.open_custom_data_provider_kt_example -> {
+                startActivity(Intent(this, CustomIndexableDataProviderKotlinExample::class.java))
+                true
+            }
+            R.id.open_custom_data_provider_java_example -> {
+                startActivity(Intent(this, CustomIndexableDataProviderJavaExample::class.java))
                 true
             }
             R.id.custom_theme_example -> {

--- a/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderJavaExample.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderJavaExample.java
@@ -1,0 +1,280 @@
+package com.mapbox.search.sample.api;
+
+import android.os.Bundle;
+import android.util.Log;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import com.mapbox.geojson.Point;
+import com.mapbox.search.AsyncOperationTask;
+import com.mapbox.search.CompletionCallback;
+import com.mapbox.search.IndexableDataProvidersRegistry;
+import com.mapbox.search.MapboxSearchSdk;
+import com.mapbox.search.ResponseInfo;
+import com.mapbox.search.SearchEngine;
+import com.mapbox.search.SearchOptions;
+import com.mapbox.search.SearchRequestTask;
+import com.mapbox.search.SearchSelectionCallback;
+import com.mapbox.search.record.FavoriteRecord;
+import com.mapbox.search.record.IndexableDataProvider;
+import com.mapbox.search.record.IndexableDataProviderEngineLayer;
+import com.mapbox.search.record.IndexableRecord;
+import com.mapbox.search.result.SearchResult;
+import com.mapbox.search.result.SearchResultType;
+import com.mapbox.search.result.SearchSuggestion;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import androidx.annotation.NonNull;
+import java.util.Map;
+import java.util.UUID;
+import kotlin.Unit;
+
+public class CustomIndexableDataProviderJavaExample extends AppCompatActivity {
+
+    private SearchEngine searchEngine;
+    private AsyncOperationTask registerProviderTask;
+    @Nullable
+    private SearchRequestTask searchRequestTask = null;
+
+    private final InMemoryDataProvider<IndexableRecord> customDataProvider = new InMemoryDataProvider<>(
+        Arrays.asList(
+            createRecord("Let it be", Point.fromLngLat(27.575321258282806, 53.89025545661358)),
+            createRecord("Laŭka", Point.fromLngLat(27.574862357961212, 53.88998973246244)),
+            createRecord("Underdog", Point.fromLngLat(27.57573285942709, 53.89020312748444))
+        )
+    );
+
+    private final SearchSelectionCallback searchCallback = new SearchSelectionCallback() {
+        @Override
+        public void onSuggestions(@NonNull List<? extends SearchSuggestion> suggestions, @NonNull ResponseInfo responseInfo) {
+            if (suggestions.isEmpty()) {
+                Log.i("SearchApiExample", "No suggestions found");
+            } else {
+                Log.i("SearchApiExample", "Search suggestions: " + suggestions + ".\nSelecting first suggestion...");
+                searchRequestTask = searchEngine.select(suggestions.get(0), this);
+            }
+        }
+
+        @Override
+        public void onResult(@NonNull SearchSuggestion suggestion, @NonNull SearchResult result, @NonNull ResponseInfo responseInfo) {
+            Log.i("SearchApiExample", "Search result: " + result);
+        }
+
+        @Override
+        public void onCategoryResult(@NonNull SearchSuggestion suggestion, @NonNull List<? extends SearchResult> results, @NonNull ResponseInfo responseInfo) {
+            Log.i("SearchApiExample", "Category search results: " + results);
+        }
+
+        @Override
+        public void onError(@NonNull Exception e) {
+            Log.i("SearchApiExample", "Search error", e);
+        }
+    };
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        searchEngine = MapboxSearchSdk.createSearchEngine();
+
+        Log.i("SearchApiExample", "Start CustomDataProvider registering...");
+        registerProviderTask = MapboxSearchSdk.getServiceProvider().globalDataProvidersRegistry().register(
+            customDataProvider,
+            200,
+            new IndexableDataProvidersRegistry.Callback() {
+                @Override
+                public void onSuccess() {
+                    Log.i("SearchApiExample", "CustomDataProvider is registered");
+                    searchRequestTask = searchEngine.search(
+                        "Underdog",
+                        new SearchOptions.Builder()
+                            .proximity(Point.fromLngLat(27.574862357961212, 53.88998973246244))
+                            .build(),
+                        searchCallback
+                    );
+                }
+
+                @Override
+                public void onError(@NonNull Exception e) {
+                    Log.i("SearchApiExample", "Error during registering", e);
+                }
+            }
+        );
+    }
+
+    @Override
+    protected void onDestroy() {
+        registerProviderTask.cancel();
+
+        if (searchRequestTask != null) {
+            searchRequestTask.cancel();
+        }
+        MapboxSearchSdk.getServiceProvider().globalDataProvidersRegistry().unregister(
+            customDataProvider,
+            new IndexableDataProvidersRegistry.Callback() {
+                @Override
+                public void onSuccess() {
+                    Log.i("SearchApiExample", "CustomDataProvider is unregistered");
+                }
+
+                @Override
+                public void onError(@NonNull Exception e) {
+                    Log.i("SearchApiExample", "Error during unregistering", e);
+                }
+            }
+        );
+
+        super.onDestroy();
+    }
+
+    private IndexableRecord createRecord(String name, Point coordinate) {
+        return new FavoriteRecord(
+            UUID.randomUUID().toString(),
+            name,
+            null,
+            null,
+            null,
+            Collections.emptyList(),
+            null,
+            coordinate,
+            SearchResultType.POI,
+            null
+        );
+    }
+
+    private static class InMemoryDataProvider<R extends IndexableRecord> implements IndexableDataProvider<R> {
+
+        private final List<IndexableDataProviderEngineLayer> dataProviderEngineLayers = new ArrayList<>();
+        private final Map<String, R> records = new LinkedHashMap<>();
+
+        InMemoryDataProvider(List<R> records) {
+            for (R record : records) {
+                this.records.put(record.getId(), record);
+            }
+        }
+
+        @NonNull
+        @Override
+        public String getDataProviderName() {
+            return "SAMPLE_APP_CUSTOM_DATA_PROVIDER";
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask registerIndexableDataProviderEngineLayer(
+            @NonNull IndexableDataProviderEngineLayer dataProviderEngine,
+            @NonNull CompletionCallback<Unit> callback
+        ) {
+            dataProviderEngine.addAll(records.values());
+            dataProviderEngineLayers.add(dataProviderEngine);
+            callback.onComplete(Unit.INSTANCE);
+            return CompletedAsyncOperationTask.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask unregisterIndexableDataProviderEngineLayer(
+            @NonNull IndexableDataProviderEngineLayer dataProviderEngine,
+            @NonNull CompletionCallback<Boolean> callback
+        ) {
+            boolean isRemoved = dataProviderEngineLayers.remove(dataProviderEngine);
+            if (isRemoved) {
+                dataProviderEngine.clear();
+            }
+            callback.onComplete(isRemoved);
+            return CompletedAsyncOperationTask.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask get(@NonNull String id, @NonNull CompletionCallback<? super R> callback) {
+            callback.onComplete(records.get(id));
+            return CompletedAsyncOperationTask.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask getAll(@NonNull CompletionCallback<List<R>> callback) {
+            callback.onComplete(new ArrayList<>(records.values()));
+            return CompletedAsyncOperationTask.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask contains(@NonNull String id, @NonNull CompletionCallback<Boolean> callback) {
+            callback.onComplete(records.get(id) != null);
+            return CompletedAsyncOperationTask.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask add(@NonNull R record, @NonNull CompletionCallback<Unit> callback) {
+            records.put(record.getId(), record);
+            callback.onComplete(Unit.INSTANCE);
+            return CompletedAsyncOperationTask.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask addAll(
+            @NonNull List<? extends R> records,
+            @NonNull CompletionCallback<Unit> callback
+        ) {
+            for (R record: records) {
+                this.records.put(record.getId(), record);
+            }
+            callback.onComplete(Unit.INSTANCE);
+            return CompletedAsyncOperationTask.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask update(@NonNull R record, @NonNull CompletionCallback<Unit> callback) {
+            records.put(record.getId(), record);
+            callback.onComplete(Unit.INSTANCE);
+            return CompletedAsyncOperationTask.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask remove(@NonNull String id, @NonNull CompletionCallback<Boolean> callback) {
+            boolean isRemoved = records.remove(id) != null;
+            callback.onComplete(isRemoved);
+            return CompletedAsyncOperationTask.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public AsyncOperationTask clear(@NonNull CompletionCallback<Unit> callback) {
+            records.clear();
+            callback.onComplete(Unit.INSTANCE);
+            return CompletedAsyncOperationTask.getInstance();
+        }
+    }
+
+    private static class CompletedAsyncOperationTask implements AsyncOperationTask {
+
+        private static final CompletedAsyncOperationTask INSTANCE = new CompletedAsyncOperationTask();
+
+        public static CompletedAsyncOperationTask getInstance() {
+            return INSTANCE;
+        }
+
+        @Override
+        public boolean isDone() {
+            return true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public void cancel() {
+            // Do nothing
+        }
+    }
+}

--- a/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderKotlinExample.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderKotlinExample.kt
@@ -1,0 +1,229 @@
+package com.mapbox.search.sample.api
+
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.geojson.Point
+import com.mapbox.search.AsyncOperationTask
+import com.mapbox.search.CompletionCallback
+import com.mapbox.search.IndexableDataProvidersRegistry
+import com.mapbox.search.MapboxSearchSdk
+import com.mapbox.search.ResponseInfo
+import com.mapbox.search.SearchEngine
+import com.mapbox.search.SearchOptions
+import com.mapbox.search.SearchRequestTask
+import com.mapbox.search.SearchSelectionCallback
+import com.mapbox.search.record.FavoriteRecord
+import com.mapbox.search.record.IndexableDataProvider
+import com.mapbox.search.record.IndexableDataProviderEngineLayer
+import com.mapbox.search.record.IndexableRecord
+import com.mapbox.search.result.SearchResult
+import com.mapbox.search.result.SearchResultType
+import com.mapbox.search.result.SearchSuggestion
+import java.util.ArrayList
+import java.util.UUID
+
+class CustomIndexableDataProviderKotlinExample : AppCompatActivity() {
+
+    private lateinit var searchEngine: SearchEngine
+    private lateinit var registerProviderTask: AsyncOperationTask
+    private var searchRequestTask: SearchRequestTask? = null
+
+    private val customDataProvider = InMemoryDataProvider(
+        records = listOf(
+            createRecord("Let it be", Point.fromLngLat(27.575321258282806, 53.89025545661358)),
+            createRecord("Laŭka", Point.fromLngLat(27.574862357961212, 53.88998973246244)),
+            createRecord("Underdog", Point.fromLngLat(27.57573285942709, 53.89020312748444)),
+        )
+    )
+
+    private val searchCallback = object : SearchSelectionCallback {
+
+        override fun onSuggestions(suggestions: List<SearchSuggestion>, responseInfo: ResponseInfo) {
+            if (suggestions.isEmpty()) {
+                Log.i("SearchApiExample", "No suggestions found")
+            } else {
+                Log.i("SearchApiExample", "Search suggestions: $suggestions.\nSelecting first suggestion...")
+                searchRequestTask = searchEngine.select(suggestions.first(), this)
+            }
+        }
+
+        override fun onResult(
+            suggestion: SearchSuggestion,
+            result: SearchResult,
+            responseInfo: ResponseInfo
+        ) {
+            Log.i("SearchApiExample", "Search result: $result")
+        }
+
+        override fun onCategoryResult(
+            suggestion: SearchSuggestion,
+            results: List<SearchResult>,
+            responseInfo: ResponseInfo
+        ) {
+            Log.i("SearchApiExample", "Category search results: $results")
+        }
+
+        override fun onError(e: Exception) {
+            Log.i("SearchApiExample", "Search error", e)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        searchEngine = MapboxSearchSdk.createSearchEngine()
+
+        Log.i("SearchApiExample", "Start CustomDataProvider registering...")
+        registerProviderTask = MapboxSearchSdk.serviceProvider.globalDataProvidersRegistry().register(
+            customDataProvider,
+            200,
+            object : IndexableDataProvidersRegistry.Callback {
+                override fun onSuccess() {
+                    Log.i("SearchApiExample", "CustomDataProvider is registered")
+                    searchRequestTask = searchEngine.search(
+                        "Underdog",
+                        SearchOptions(
+                            proximity = Point.fromLngLat(27.574862357961212, 53.88998973246244),
+                        ),
+                        searchCallback
+                    )
+                }
+
+                override fun onError(e: Exception) {
+                    Log.i("SearchApiExample", "Error during registering", e)
+                }
+            }
+        )
+    }
+
+    override fun onDestroy() {
+        registerProviderTask.cancel()
+        searchRequestTask?.cancel()
+        MapboxSearchSdk.serviceProvider.globalDataProvidersRegistry().unregister(
+            customDataProvider,
+            object : IndexableDataProvidersRegistry.Callback {
+                override fun onSuccess() {
+                    Log.i("SearchApiExample", "CustomDataProvider is unregistered")
+                }
+
+                override fun onError(e: Exception) {
+                    Log.i("SearchApiExample", "Error during unregistering", e)
+                }
+            }
+        )
+        super.onDestroy()
+    }
+
+    private fun createRecord(name: String, coordinate: Point): IndexableRecord {
+        return FavoriteRecord(
+            UUID.randomUUID().toString(),
+            name,
+            null,
+            null,
+            null,
+            emptyList(),
+            null,
+            coordinate,
+            SearchResultType.POI,
+            null,
+        )
+    }
+
+    private class InMemoryDataProvider<R : IndexableRecord>(records: List<R>) : IndexableDataProvider<R> {
+
+        private val dataProviderEngineLayers: MutableList<IndexableDataProviderEngineLayer> = mutableListOf()
+        private val records: MutableMap<String, R> = mutableMapOf()
+
+        override val dataProviderName: String = "SAMPLE_APP_CUSTOM_DATA_PROVIDER"
+
+        init {
+            this.records.putAll(records.map { it.id to it })
+        }
+
+        override fun registerIndexableDataProviderEngineLayer(
+            dataProviderEngineLayer: IndexableDataProviderEngineLayer,
+            callback: CompletionCallback<Unit>
+        ): AsyncOperationTask {
+            dataProviderEngineLayer.addAll(records.values.toList())
+            dataProviderEngineLayers.add(dataProviderEngineLayer)
+            callback.onComplete(Unit)
+            return CompletedAsyncOperationTask
+        }
+
+        override fun unregisterIndexableDataProviderEngineLayer(
+            dataProviderEngineLayer: IndexableDataProviderEngineLayer,
+            callback: CompletionCallback<Boolean>
+        ): AsyncOperationTask {
+            val isRemoved = dataProviderEngineLayers.remove(dataProviderEngineLayer)
+            if (isRemoved) {
+                dataProviderEngineLayer.clear()
+            }
+            callback.onComplete(isRemoved)
+            return CompletedAsyncOperationTask
+        }
+
+        override operator fun get(id: String, callback: CompletionCallback<in R?>): AsyncOperationTask {
+            callback.onComplete(records[id])
+            return CompletedAsyncOperationTask
+        }
+
+        override fun getAll(callback: CompletionCallback<List<R>>): AsyncOperationTask {
+            callback.onComplete(ArrayList(records.values))
+            return CompletedAsyncOperationTask
+        }
+
+        override fun contains(id: String, callback: CompletionCallback<Boolean>): AsyncOperationTask {
+            callback.onComplete(records[id] != null)
+            return CompletedAsyncOperationTask
+        }
+
+        override fun add(record: R, callback: CompletionCallback<Unit>): AsyncOperationTask {
+            records[record.id] = record
+            callback.onComplete(Unit)
+            return CompletedAsyncOperationTask
+        }
+
+        override fun addAll(
+            records: List<R>,
+            callback: CompletionCallback<Unit>
+        ): AsyncOperationTask {
+            for (record in records) {
+                this.records[record.id] = record
+            }
+            callback.onComplete(Unit)
+            return CompletedAsyncOperationTask
+        }
+
+        override fun update(record: R, callback: CompletionCallback<Unit>): AsyncOperationTask {
+            records[record.id] = record
+            callback.onComplete(Unit)
+            return CompletedAsyncOperationTask
+        }
+
+        override fun remove(id: String, callback: CompletionCallback<Boolean>): AsyncOperationTask {
+            val isRemoved = records.remove(id) != null
+            callback.onComplete(isRemoved)
+            return CompletedAsyncOperationTask
+        }
+
+        override fun clear(callback: CompletionCallback<Unit>): AsyncOperationTask {
+            records.clear()
+            callback.onComplete(Unit)
+            return CompletedAsyncOperationTask
+        }
+    }
+
+    private object CompletedAsyncOperationTask : AsyncOperationTask {
+
+        override val isDone: Boolean
+            get() = true
+
+        override val isCancelled: Boolean
+            get() = false
+
+        override fun cancel() {
+            // Do nothing
+        }
+    }
+}

--- a/app/src/main/java/com/mapbox/search/sample/api/FavoritesDataProviderJavaExample.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/FavoritesDataProviderJavaExample.java
@@ -3,6 +3,7 @@ package com.mapbox.search.sample.api;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -11,16 +12,13 @@ import com.mapbox.search.AsyncOperationTask;
 import com.mapbox.search.MapboxSearchSdk;
 import com.mapbox.search.record.FavoriteRecord;
 import com.mapbox.search.record.FavoritesDataProvider;
-import com.mapbox.search.record.IndexableDataProvider.CompletionCallback;
+import com.mapbox.search.CompletionCallback;
 import com.mapbox.search.record.LocalDataProvider.OnDataChangedListener;
 import com.mapbox.search.result.SearchAddress;
 import com.mapbox.search.result.SearchResultType;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.Future;
 
 import kotlin.Unit;
 
@@ -37,7 +35,7 @@ public class FavoritesDataProviderJavaExample extends AppCompatActivity {
         }
 
         @Override
-        public void onError(@NotNull Exception e) {
+        public void onError(@NonNull Exception e) {
             Log.i("SearchApiExample", "Unable to retrieve favorite records", e);
         }
     };
@@ -50,7 +48,7 @@ public class FavoritesDataProviderJavaExample extends AppCompatActivity {
         }
 
         @Override
-        public void onError(@NotNull Exception e) {
+        public void onError(@NonNull Exception e) {
             Log.i("SearchApiExample", "Unable to add a new favorite record", e);
         }
     };

--- a/app/src/main/java/com/mapbox/search/sample/api/FavoritesDataProviderKotlinExample.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/FavoritesDataProviderKotlinExample.kt
@@ -5,9 +5,9 @@ import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.geojson.Point
 import com.mapbox.search.AsyncOperationTask
+import com.mapbox.search.CompletionCallback
 import com.mapbox.search.MapboxSearchSdk.serviceProvider
 import com.mapbox.search.record.FavoriteRecord
-import com.mapbox.search.record.IndexableDataProvider.CompletionCallback
 import com.mapbox.search.record.LocalDataProvider.OnDataChangedListener
 import com.mapbox.search.result.SearchAddress
 import com.mapbox.search.result.SearchResultType

--- a/app/src/main/java/com/mapbox/search/sample/api/HistoryDataProviderJavaExample.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/HistoryDataProviderJavaExample.java
@@ -4,15 +4,14 @@ import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.search.AsyncOperationTask;
 import com.mapbox.search.MapboxSearchSdk;
 import com.mapbox.search.record.HistoryDataProvider;
 import com.mapbox.search.record.HistoryRecord;
-import com.mapbox.search.record.IndexableDataProvider.CompletionCallback;
-
-import org.jetbrains.annotations.NotNull;
+import com.mapbox.search.CompletionCallback;
 
 import java.util.List;
 
@@ -29,7 +28,7 @@ public class HistoryDataProviderJavaExample extends AppCompatActivity {
         }
 
         @Override
-        public void onError(@NotNull Exception e) {
+        public void onError(@NonNull Exception e) {
             Log.i("SearchApiExample", "Unable to retrieve history records", e);
         }
     };

--- a/app/src/main/java/com/mapbox/search/sample/api/HistoryDataProviderKotlinExample.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/HistoryDataProviderKotlinExample.kt
@@ -4,9 +4,9 @@ import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.search.AsyncOperationTask
+import com.mapbox.search.CompletionCallback
 import com.mapbox.search.MapboxSearchSdk.serviceProvider
 import com.mapbox.search.record.HistoryRecord
-import com.mapbox.search.record.IndexableDataProvider.CompletionCallback
 
 class HistoryDataProviderKotlinExample : AppCompatActivity() {
 

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
@@ -7,23 +7,40 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.mapbox.geojson.Point;
+import com.mapbox.search.AsyncOperationTask;
+import com.mapbox.search.CompletionCallback;
 import com.mapbox.search.MapboxSearchSdk;
 import com.mapbox.search.OfflineSearchEngine;
+import com.mapbox.search.OfflineSearchEngine.EngineReadyCallback;
 import com.mapbox.search.OfflineSearchOptions;
+import com.mapbox.search.OfflineTileRegion;
 import com.mapbox.search.ResponseInfo;
 import com.mapbox.search.SearchRequestTask;
 import com.mapbox.search.SearchSelectionCallback;
 import com.mapbox.search.result.SearchResult;
 import com.mapbox.search.result.SearchSuggestion;
 
-import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 public class OfflineSearchJavaExampleActivity extends AppCompatActivity {
 
     private OfflineSearchEngine searchEngine;
+    private AsyncOperationTask tilesLoadingTask;
+    @Nullable
     private SearchRequestTask searchRequestTask;
+
+    private final EngineReadyCallback engineReadyCallback = new EngineReadyCallback() {
+        @Override
+        public void onEngineReady(@NonNull List<OfflineTileRegion> offlineTileRegions) {
+            Log.i("SearchApiExample", "Engine is ready, available regions: " + offlineTileRegions);
+        }
+
+        @Override
+        public void onError(@NonNull Exception e) {
+            Log.i("SearchApiExample", "Error during engine initialization", e);
+        }
+    };
 
     private final SearchSelectionCallback searchCallback = new SearchSelectionCallback() {
 
@@ -58,37 +75,39 @@ public class OfflineSearchJavaExampleActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         searchEngine = MapboxSearchSdk.getOfflineSearchEngine();
+        searchEngine.addEngineReadyCallback(engineReadyCallback);
 
-        /*
-         * TODO Change function arguments to what's available on your device.
-         * Make sure each region added only once.
-         */
-        searchEngine.addOfflineRegion(
-            new File(getFilesDir(), "offline_data/germany").getPath(),
-            Collections.singletonList("germany.map.cont"),
-            "germany.boundary.cont",
-            new OfflineSearchEngine.AddRegionCallback() {
+        Log.i("SearchApiExample", "Loading tiles...");
+        tilesLoadingTask = searchEngine.loadTileRegion(
+            "Washington DC",
+            Point.fromLngLat(-77.0339911055176, 38.899920004207516),
+            new CompletionCallback<List<OfflineTileRegion>>() {
                 @Override
-                public void onAdded() {
-                    Log.i("SearchApiExample", "Offline region has been added");
+                public void onComplete(List<OfflineTileRegion> result) {
+                    Log.i("SearchApiExample", "Tiles successfully loaded");
+
+                    searchRequestTask = searchEngine.search(
+                        "Cafe",
+                        new OfflineSearchOptions(),
+                        searchCallback
+                    );
                 }
 
                 @Override
                 public void onError(@NonNull Exception e) {
-                    Log.i("SearchApiExample", "Unable to add offline region", e);
+                    Log.i("SearchApiExample", "Tiles loading error", e);
                 }
             }
         );
-
-        final OfflineSearchOptions options = new OfflineSearchOptions.Builder()
-            .build();
-
-        searchRequestTask = searchEngine.search("Berlin", options, searchCallback);
     }
 
     @Override
     protected void onDestroy() {
-        searchRequestTask.cancel();
+        searchEngine.removeEngineReadyCallback(engineReadyCallback);
+        tilesLoadingTask.cancel();
+        if (searchRequestTask != null) {
+            searchRequestTask.cancel();
+        }
         super.onDestroy();
     }
 }

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
@@ -3,20 +3,34 @@ package com.mapbox.search.sample.api
 import android.app.Activity
 import android.os.Bundle
 import android.util.Log
+import com.mapbox.geojson.Point
+import com.mapbox.search.AsyncOperationTask
+import com.mapbox.search.CompletionCallback
 import com.mapbox.search.MapboxSearchSdk
 import com.mapbox.search.OfflineSearchEngine
 import com.mapbox.search.OfflineSearchOptions
+import com.mapbox.search.OfflineTileRegion
 import com.mapbox.search.ResponseInfo
 import com.mapbox.search.SearchRequestTask
 import com.mapbox.search.SearchSelectionCallback
 import com.mapbox.search.result.SearchResult
 import com.mapbox.search.result.SearchSuggestion
-import java.io.File
 
 class OfflineSearchKotlinExampleActivity : Activity() {
 
     private lateinit var searchEngine: OfflineSearchEngine
-    private lateinit var searchRequestTask: SearchRequestTask
+    private lateinit var tilesLoadingTask: AsyncOperationTask
+    private var searchRequestTask: SearchRequestTask? = null
+
+    private val engineReadyCallback = object : OfflineSearchEngine.EngineReadyCallback {
+        override fun onEngineReady(offlineTileRegions: List<OfflineTileRegion>) {
+            Log.i("SearchApiExample", "Engine is ready, available regions: $offlineTileRegions")
+        }
+
+        override fun onError(e: Exception) {
+            Log.i("SearchApiExample", "Error during engine initialization", e)
+        }
+    }
 
     private val searchCallback = object : SearchSelectionCallback {
 
@@ -54,35 +68,34 @@ class OfflineSearchKotlinExampleActivity : Activity() {
         super.onCreate(savedInstanceState)
 
         searchEngine = MapboxSearchSdk.getOfflineSearchEngine()
+        searchEngine.addEngineReadyCallback(engineReadyCallback)
 
-        /**
-         * TODO Change function arguments to what's available on your device.
-         * Make sure each region added only once.
-         */
-        searchEngine.addOfflineRegion(
-            path = File(filesDir, "offline_data/germany").path,
-            mapsFileNames = listOf("germany.map.cont"),
-            boundaryFileName = "germany.boundary.cont",
-            callback = object : OfflineSearchEngine.AddRegionCallback {
-                override fun onAdded() {
-                    Log.i("SearchApiExample", "Offline region has been added")
+        Log.i("SearchApiExample", "Loading tiles...")
+        tilesLoadingTask = searchEngine.loadTileRegion(
+            groupId = "Washington DC",
+            geometry = Point.fromLngLat(-77.0339911055176, 38.899920004207516),
+            callback = object : CompletionCallback<List<OfflineTileRegion>> {
+                override fun onComplete(result: List<OfflineTileRegion>) {
+                    Log.i("SearchApiExample", "Tiles successfully loaded")
+
+                    searchRequestTask = searchEngine.search(
+                        "Cafe",
+                        OfflineSearchOptions(),
+                        searchCallback
+                    )
                 }
 
-                override fun onError(e: java.lang.Exception) {
-                    Log.i("SearchApiExample", "Unable to add offline region", e)
+                override fun onError(e: Exception) {
+                    Log.i("SearchApiExample", "Tiles loading error", e)
                 }
             }
-        )
-
-        searchRequestTask = searchEngine.search(
-            "Berlin",
-            OfflineSearchOptions(),
-            searchCallback
         )
     }
 
     override fun onDestroy() {
-        searchRequestTask.cancel()
+        searchEngine.removeEngineReadyCallback(engineReadyCallback)
+        tilesLoadingTask.cancel()
+        searchRequestTask?.cancel()
         super.onDestroy()
     }
 }

--- a/app/src/main/res/menu/main_activity_options_menu.xml
+++ b/app/src/main/res/menu/main_activity_options_menu.xml
@@ -8,6 +8,16 @@
         />
 
     <item
+        android:id="@+id/open_custom_data_provider_kt_example"
+        android:title="@string/action_open_custom_data_provider_kt_example"
+        />
+
+    <item
+        android:id="@+id/open_custom_data_provider_java_example"
+        android:title="@string/action_open_custom_data_provider_java_example"
+        />
+
+    <item
         android:id="@+id/custom_theme_example"
         android:title="@string/action_open_custom_theme_example"
         />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="action_open_history_data_provider_java_example">Open History Data Provider Java example</string>
     <string name="action_open_favorites_data_provider_kt_example">Open Favorites Data Provider Kotlin example</string>
     <string name="action_open_favorites_data_provider_java_example">Open Favorites Data Provider Java example</string>
+    <string name="action_open_custom_data_provider_java_example">Open custom data provider Java example</string>
+    <string name="action_open_custom_data_provider_kt_example">Open custom data provider Kotlin example</string>
 
     <string name="action_open_maps_integration_example">Open Maps integration example</string>
 


### PR DESCRIPTION
## 1.0.0-beta.19

### Breaking changes
- [CORE] `IndexableDataProvider.CompletionCallback` has been moved to upper level package `com.mapbox.search`.

### New features
- [CORE] Now customers can override logger. See [Mapbox Android Modularization](https://github.com/mapbox/mapbox-base-android/blob/master/MODULARIZATION.md) for more information.
- [CORE] A new functionality to work with offline data has been added to `OfflineSearchEngine`.
- [CORE] Now customers can add custom data providers. As a result, new classes (`IndexableDataProvidersRegistry` and `IndexableDataProviderEngineLayer`) have been added and also few extra methods and properties have been added to exisitng API. Take a look at new samples for more information.
- [CORE] New functions `MapboxSearchSdk.addDataProviderInitializationCallback()` and `MapboxSearchSdk.removeDataProviderInitializationCallback()` have been introduced. Now users can receive notifications about default data providers (history and favorites) successful or failed initialization.

### Bug fixes
- [CORE] Fix failed Search SDK requests for cases, when application label contains non-ASCII symbols.

### Mapbox dependencies
- Common SDK `18.0.0`
- Telemetry SDK `8.1.0`