### PR TITLE
Search SDK v1.0.0-beta.20

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,14 +47,14 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
 
     // Loader module is excluded just for custom library loader example.
     // Don't exclude it if you are good with a default loader.
-    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.19") {
+    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.20") {
         exclude group: "com.mapbox.common", module: "loader"
     }
-    implementation ("com.mapbox.maps:android:10.0.0-rc.8") {
+    implementation ("com.mapbox.maps:android:10.0.0-rc.9") {
         exclude group: "com.mapbox.common", module: "loader"
     }
 

--- a/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderKotlinExample.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderKotlinExample.kt
@@ -22,6 +22,7 @@ import com.mapbox.search.result.SearchResultType
 import com.mapbox.search.result.SearchSuggestion
 import java.util.ArrayList
 import java.util.UUID
+import java.util.concurrent.Executor
 
 class CustomIndexableDataProviderKotlinExample : AppCompatActivity() {
 
@@ -143,73 +144,104 @@ class CustomIndexableDataProviderKotlinExample : AppCompatActivity() {
 
         override fun registerIndexableDataProviderEngineLayer(
             dataProviderEngineLayer: IndexableDataProviderEngineLayer,
+            executor: Executor,
             callback: CompletionCallback<Unit>
         ): AsyncOperationTask {
             dataProviderEngineLayer.addAll(records.values.toList())
             dataProviderEngineLayers.add(dataProviderEngineLayer)
-            callback.onComplete(Unit)
+            executor.execute {
+                callback.onComplete(Unit)
+            }
             return CompletedAsyncOperationTask
         }
 
         override fun unregisterIndexableDataProviderEngineLayer(
             dataProviderEngineLayer: IndexableDataProviderEngineLayer,
+            executor: Executor,
             callback: CompletionCallback<Boolean>
         ): AsyncOperationTask {
             val isRemoved = dataProviderEngineLayers.remove(dataProviderEngineLayer)
             if (isRemoved) {
                 dataProviderEngineLayer.clear()
             }
-            callback.onComplete(isRemoved)
+            executor.execute {
+                callback.onComplete(isRemoved)
+            }
             return CompletedAsyncOperationTask
         }
 
-        override operator fun get(id: String, callback: CompletionCallback<in R?>): AsyncOperationTask {
-            callback.onComplete(records[id])
+        override operator fun get(
+            id: String,
+            executor: Executor,
+            callback: CompletionCallback<in R?>
+        ): AsyncOperationTask {
+            executor.execute {
+                callback.onComplete(records[id])
+            }
             return CompletedAsyncOperationTask
         }
 
-        override fun getAll(callback: CompletionCallback<List<R>>): AsyncOperationTask {
-            callback.onComplete(ArrayList(records.values))
+        override fun getAll(executor: Executor, callback: CompletionCallback<List<R>>): AsyncOperationTask {
+            executor.execute {
+                callback.onComplete(ArrayList(records.values))
+            }
             return CompletedAsyncOperationTask
         }
 
-        override fun contains(id: String, callback: CompletionCallback<Boolean>): AsyncOperationTask {
-            callback.onComplete(records[id] != null)
+        override fun contains(
+            id: String,
+            executor: Executor,
+            callback: CompletionCallback<Boolean>
+        ): AsyncOperationTask {
+            executor.execute {
+                callback.onComplete(records[id] != null)
+            }
             return CompletedAsyncOperationTask
         }
 
-        override fun add(record: R, callback: CompletionCallback<Unit>): AsyncOperationTask {
+        override fun add(record: R, executor: Executor, callback: CompletionCallback<Unit>): AsyncOperationTask {
             records[record.id] = record
-            callback.onComplete(Unit)
+            executor.execute {
+                callback.onComplete(Unit)
+            }
             return CompletedAsyncOperationTask
         }
 
         override fun addAll(
             records: List<R>,
+            executor: Executor,
             callback: CompletionCallback<Unit>
         ): AsyncOperationTask {
             for (record in records) {
                 this.records[record.id] = record
             }
-            callback.onComplete(Unit)
+            executor.execute {
+                callback.onComplete(Unit)
+            }
             return CompletedAsyncOperationTask
         }
 
-        override fun update(record: R, callback: CompletionCallback<Unit>): AsyncOperationTask {
+        override fun update(record: R, executor: Executor, callback: CompletionCallback<Unit>): AsyncOperationTask {
             records[record.id] = record
-            callback.onComplete(Unit)
+            executor.execute {
+                callback.onComplete(Unit)
+            }
             return CompletedAsyncOperationTask
         }
 
-        override fun remove(id: String, callback: CompletionCallback<Boolean>): AsyncOperationTask {
+        override fun remove(id: String, executor: Executor, callback: CompletionCallback<Boolean>): AsyncOperationTask {
             val isRemoved = records.remove(id) != null
-            callback.onComplete(isRemoved)
+            executor.execute {
+                callback.onComplete(isRemoved)
+            }
             return CompletedAsyncOperationTask
         }
 
-        override fun clear(callback: CompletionCallback<Unit>): AsyncOperationTask {
+        override fun clear(executor: Executor, callback: CompletionCallback<Unit>): AsyncOperationTask {
             records.clear()
-            callback.onComplete(Unit)
+            executor.execute {
+                callback.onComplete(Unit)
+            }
             return CompletedAsyncOperationTask
         }
     }

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingJavaExampleActivity.java
@@ -67,6 +67,9 @@ public class OfflineReverseGeocodingJavaExampleActivity extends AppCompatActivit
         tilesLoadingTask = searchEngine.loadTileRegion(
             "Washington DC",
             dcLocation,
+            progress -> {
+                Log.i("SearchApiExample", "Loading progress: " + progress);
+            },
             new CompletionCallback<List<OfflineTileRegion>>() {
                 @Override
                 public void onComplete(List<OfflineTileRegion> result) {

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingKotlinExampleActivity.kt
@@ -54,7 +54,10 @@ class OfflineReverseGeocodingKotlinExampleActivity : Activity() {
         tilesLoadingTask = searchEngine.loadTileRegion(
             groupId = "Washington DC",
             geometry = dcLocation,
-            callback = object : CompletionCallback<List<OfflineTileRegion>> {
+            progressCallback = { progress ->
+                Log.i("SearchApiExample", "Loading progress: $progress")
+            },
+            completionCallback = object : CompletionCallback<List<OfflineTileRegion>> {
                 override fun onComplete(result: List<OfflineTileRegion>) {
                     Log.i("SearchApiExample", "Tiles successfully loaded")
 

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
@@ -7,6 +7,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.mapbox.common.TileRegionLoadProgress;
+import com.mapbox.common.TileRegionLoadProgressCallback;
 import com.mapbox.geojson.Point;
 import com.mapbox.search.AsyncOperationTask;
 import com.mapbox.search.CompletionCallback;
@@ -81,6 +83,9 @@ public class OfflineSearchJavaExampleActivity extends AppCompatActivity {
         tilesLoadingTask = searchEngine.loadTileRegion(
             "Washington DC",
             Point.fromLngLat(-77.0339911055176, 38.899920004207516),
+            progress -> {
+                Log.i("SearchApiExample", "Loading progress: " + progress);
+            },
             new CompletionCallback<List<OfflineTileRegion>>() {
                 @Override
                 public void onComplete(List<OfflineTileRegion> result) {

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
@@ -74,7 +74,10 @@ class OfflineSearchKotlinExampleActivity : Activity() {
         tilesLoadingTask = searchEngine.loadTileRegion(
             groupId = "Washington DC",
             geometry = Point.fromLngLat(-77.0339911055176, 38.899920004207516),
-            callback = object : CompletionCallback<List<OfflineTileRegion>> {
+            progressCallback = { progress ->
+                Log.i("SearchApiExample", "Loading progress: $progress")
+            },
+            completionCallback = object : CompletionCallback<List<OfflineTileRegion>> {
                 override fun onComplete(result: List<OfflineTileRegion>) {
                     Log.i("SearchApiExample", "Tiles successfully loaded")
 


### PR DESCRIPTION
## 1.0.0-beta.20

### Breaking changes
- [CORE] `MainThreadWorker` has a new property `mainExecutor` that returns an executor working on the main thread. All the subclasses now have to implement this property.
- [CORE] Similarly to search engines, asynchronous functions of `IndexableDataProvider` may accept optional parameter `Executor`. All the subclasses now have to implement these functions.
- [CORE] `OfflineTileRegion`'s constructor has been made internal. Also, its `copy` function has been removed.
- [CORE] Signature of the function `OfflineSearchEngine.loadTileRegion()` has been changed, now it accepts additional `progressCallback` parameter. `callback` parameter has been renamed to `completionCallback`.

### New features
- [CORE] Now you can pass `OfflineSearchSettings` to `MapboxSearchSdk.initialize()` to override offline search settings.
- [CORE] Now asynchronous functions of `SearchEngine`, `ReverseGeocodingSearchEngine`, `CategorySearchEngine`, `OfflineSearchEngine`, `IndexableDataProvider`, `IndexableDataProvidersRegistry` may accept optional parameter `Executor` used for events dispatching. By default events are still dispatched on the main thread.
- [CORE] New function `OfflineSearchEngine.getGroupInfo()` is available. This function provides group meta info.
- [CORE] New function `OfflineSearchEngine.updateTilesGroup()` is available. This function updates the existing tiles group.

### Mapbox dependencies
- Common SDK `19.0.0`
- Telemetry SDK `8.1.0`