### PR TITLE
Search SDK v1.0.0-beta.21

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,10 +51,10 @@ dependencies {
 
     // Loader module is excluded just for custom library loader example.
     // Don't exclude it if you are good with a default loader.
-    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.20") {
+    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.21") {
         exclude group: "com.mapbox.common", module: "loader"
     }
-    implementation ("com.mapbox.maps:android:10.0.0-rc.9") {
+    implementation ("com.mapbox.maps:android:10.0.0") {
         exclude group: "com.mapbox.common", module: "loader"
     }
 


### PR DESCRIPTION
## 1.0.0-beta.21

### Breaking changes
- [CORE] Enum `QueryType` has a new type - `CATEGORY`. Now users can receive category-only search results. Please note: this type is restricted for internal or special use.
- [CORE] `SearchEngine.select(SearchSuggestion, Executor, SearchSelectionCallback)` method signature has been changed to `SearchEngine.select(SearchSuggestion, SelectOptions, Executor, SearchSelectionCallback)`: now user can control whether `SearchEngine` should automatically add final result to the history or not.

### New features
- [CORE] `@Deprecated` annotations for Geocoding-specific search options have been removed.
- [CORE] New function `SearchEngine.select(SearchSuggestion, SelectOptions, SearchSelectionCallback)` is available.
- [CORE] `SelectOptions` class has been introduced.

### Bug fixes
- [CORE] Fixed a bug in `OfflineSearchEngine` when tiles modifying functions such as `loadTileRegion()`, `updateTilesGroup()`, `removeTilesGroup()` were called before engine got initialized.

### Mapbox dependencies
- Common SDK `20.0.0`
- Telemetry SDK `8.1.0`