### PR TITLE
Search SDK v1.0.0-beta.22

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
     // Loader module is excluded just for custom library loader example.
     // Don't exclude it if you are good with a default loader.
-    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.21") {
+    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.22") {
         exclude group: "com.mapbox.common", module: "loader"
     }
     implementation ("com.mapbox.maps:android:10.0.0") {

--- a/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
@@ -35,6 +35,7 @@ import com.mapbox.search.sample.api.ReverseGeocodingJavaExampleActivity
 import com.mapbox.search.sample.api.ReverseGeocodingKotlinExampleActivity
 import com.mapbox.search.sample.maps.MapsIntegrationExampleActivity
 import com.mapbox.search.ui.view.SearchBottomSheetView
+import com.mapbox.search.ui.view.SearchMode
 import com.mapbox.search.ui.view.category.Category
 import com.mapbox.search.ui.view.category.SearchCategoriesBottomSheetView
 import com.mapbox.search.ui.view.place.SearchPlace
@@ -68,6 +69,7 @@ class MainActivity : AppCompatActivity() {
         searchBottomSheetView = findViewById(R.id.search_view)
         searchBottomSheetView.initializeSearch(savedInstanceState, configuration)
         searchBottomSheetView.isHideableByDrag = true
+        searchBottomSheetView.searchMode = SearchMode.AUTO
 
         searchPlaceView = findViewById(R.id.search_place_view)
         searchCategoriesView = findViewById(R.id.search_categories_view)

--- a/app/src/main/java/com/mapbox/search/sample/SearchDemoApplication.kt
+++ b/app/src/main/java/com/mapbox/search/sample/SearchDemoApplication.kt
@@ -1,7 +1,9 @@
 package com.mapbox.search.sample
 
 import android.app.Application
+import com.mapbox.common.TileStore
 import com.mapbox.search.MapboxSearchSdk
+import com.mapbox.search.OfflineSearchSettings
 import com.mapbox.search.location.DefaultLocationProvider
 
 class SearchDemoApplication : Application() {
@@ -12,7 +14,8 @@ class SearchDemoApplication : Application() {
         MapboxSearchSdk.initialize(
             application = this,
             accessToken = BuildConfig.MAPBOX_API_TOKEN,
-            locationProvider = DefaultLocationProvider(this)
+            locationProvider = DefaultLocationProvider(this),
+            offlineSearchSettings = OfflineSearchSettings(tileStore = TileStore.create()),
         )
     }
 }

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingJavaExampleActivity.java
@@ -7,32 +7,34 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.mapbox.common.Cancelable;
+import com.mapbox.common.TileRegionLoadOptions;
+import com.mapbox.common.TileStore;
+import com.mapbox.common.TilesetDescriptor;
 import com.mapbox.geojson.Point;
-import com.mapbox.search.AsyncOperationTask;
-import com.mapbox.search.CompletionCallback;
 import com.mapbox.search.MapboxSearchSdk;
 import com.mapbox.search.OfflineReverseGeoOptions;
 import com.mapbox.search.OfflineSearchEngine;
 import com.mapbox.search.OfflineSearchEngine.EngineReadyCallback;
-import com.mapbox.search.OfflineTileRegion;
 import com.mapbox.search.ResponseInfo;
 import com.mapbox.search.SearchCallback;
 import com.mapbox.search.SearchRequestTask;
 import com.mapbox.search.result.SearchResult;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class OfflineReverseGeocodingJavaExampleActivity extends AppCompatActivity {
 
     private OfflineSearchEngine searchEngine;
-    private AsyncOperationTask tilesLoadingTask;
+    private Cancelable tilesLoadingTask;
     @Nullable
     private SearchRequestTask searchRequestTask;
 
     private final EngineReadyCallback engineReadyCallback = new EngineReadyCallback() {
         @Override
-        public void onEngineReady(@NonNull List<OfflineTileRegion> offlineTileRegions) {
-            Log.i("SearchApiExample", "Engine is ready, available regions: " + offlineTileRegions);
+        public void onEngineReady() {
+            Log.i("SearchApiExample", "Engine is ready");
         }
 
         @Override
@@ -61,29 +63,36 @@ public class OfflineReverseGeocodingJavaExampleActivity extends AppCompatActivit
         searchEngine = MapboxSearchSdk.getOfflineSearchEngine();
         searchEngine.addEngineReadyCallback(engineReadyCallback);
 
+        final TileStore tileStore = searchEngine.getTileStore();
+
         final Point dcLocation = Point.fromLngLat(-77.0339911055176, 38.899920004207516);
 
+        final List<TilesetDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(searchEngine.createBoundariesTilesetDescriptor());
+        descriptors.add(searchEngine.createTilesetDescriptor());
+
+        final TileRegionLoadOptions tileRegionLoadOptions = new TileRegionLoadOptions.Builder()
+            .descriptors(descriptors)
+            .geometry(dcLocation)
+            .acceptExpired(true)
+            .build();
+
         Log.i("SearchApiExample", "Loading tiles...");
-        tilesLoadingTask = searchEngine.loadTileRegion(
+
+        tilesLoadingTask = tileStore.loadTileRegion(
             "Washington DC",
-            dcLocation,
-            progress -> {
-                Log.i("SearchApiExample", "Loading progress: " + progress);
-            },
-            new CompletionCallback<List<OfflineTileRegion>>() {
-                @Override
-                public void onComplete(List<OfflineTileRegion> result) {
+            tileRegionLoadOptions,
+            progress -> Log.i("SearchApiExample", "Loading progress: " + progress),
+            region -> {
+                if (region.isValue()) {
                     Log.i("SearchApiExample", "Tiles successfully loaded");
 
                     searchRequestTask = searchEngine.reverseGeocoding(
                         new OfflineReverseGeoOptions(dcLocation),
                         searchCallback
                     );
-                }
-
-                @Override
-                public void onError(@NonNull Exception e) {
-                    Log.i("SearchApiExample", "Tiles loading error", e);
+                } else {
+                    Log.i("SearchApiExample", "Tiles loading error: " + region.getError());
                 }
             }
         );

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingKotlinExampleActivity.kt
@@ -3,13 +3,12 @@ package com.mapbox.search.sample.api
 import android.app.Activity
 import android.os.Bundle
 import android.util.Log
+import com.mapbox.common.Cancelable
+import com.mapbox.common.TileRegionLoadOptions
 import com.mapbox.geojson.Point
-import com.mapbox.search.AsyncOperationTask
-import com.mapbox.search.CompletionCallback
 import com.mapbox.search.MapboxSearchSdk
 import com.mapbox.search.OfflineReverseGeoOptions
 import com.mapbox.search.OfflineSearchEngine
-import com.mapbox.search.OfflineTileRegion
 import com.mapbox.search.ResponseInfo
 import com.mapbox.search.SearchCallback
 import com.mapbox.search.SearchRequestTask
@@ -18,12 +17,12 @@ import com.mapbox.search.result.SearchResult
 class OfflineReverseGeocodingKotlinExampleActivity : Activity() {
 
     private lateinit var searchEngine: OfflineSearchEngine
-    private lateinit var tilesLoadingTask: AsyncOperationTask
+    private lateinit var tilesLoadingTask: Cancelable
     private var searchRequestTask: SearchRequestTask? = null
 
     private val engineReadyCallback = object : OfflineSearchEngine.EngineReadyCallback {
-        override fun onEngineReady(offlineTileRegions: List<OfflineTileRegion>) {
-            Log.i("SearchApiExample", "Engine is ready, available regions: $offlineTileRegions")
+        override fun onEngineReady() {
+            Log.i("SearchApiExample", "Engine is ready")
         }
 
         override fun onError(e: Exception) {
@@ -48,27 +47,36 @@ class OfflineReverseGeocodingKotlinExampleActivity : Activity() {
         searchEngine = MapboxSearchSdk.getOfflineSearchEngine()
         searchEngine.addEngineReadyCallback(engineReadyCallback)
 
+        val tileStore = searchEngine.tileStore
+
         val dcLocation = Point.fromLngLat(-77.0339911055176, 38.899920004207516)
 
-        Log.i("SearchApiExample", "Loading tiles...")
-        tilesLoadingTask = searchEngine.loadTileRegion(
-            groupId = "Washington DC",
-            geometry = dcLocation,
-            progressCallback = { progress ->
-                Log.i("SearchApiExample", "Loading progress: $progress")
-            },
-            completionCallback = object : CompletionCallback<List<OfflineTileRegion>> {
-                override fun onComplete(result: List<OfflineTileRegion>) {
-                    Log.i("SearchApiExample", "Tiles successfully loaded")
+        val descriptors = mutableListOf(
+            searchEngine.createBoundariesTilesetDescriptor(),
+            searchEngine.createTilesetDescriptor()
+        )
 
+        val tileRegionLoadOptions = TileRegionLoadOptions.Builder()
+            .descriptors(descriptors)
+            .geometry(dcLocation)
+            .acceptExpired(true)
+            .build()
+
+        Log.i("SearchApiExample", "Loading tiles...")
+
+        tilesLoadingTask = tileStore.loadTileRegion(
+            "Washington DC",
+            tileRegionLoadOptions,
+            { progress -> Log.i("SearchApiExample", "Loading progress: $progress") },
+            { region ->
+                if (region.isValue) {
+                    Log.i("SearchApiExample", "Tiles successfully loaded")
                     searchRequestTask = searchEngine.reverseGeocoding(
                         OfflineReverseGeoOptions(center = dcLocation),
                         searchCallback
                     )
-                }
-
-                override fun onError(e: Exception) {
-                    Log.i("SearchApiExample", "Tiles loading error", e)
+                } else {
+                    Log.i("SearchApiExample", "Tiles loading error: ${region.error}")
                 }
             }
         )


### PR DESCRIPTION
## 1.0.0-beta.22

### Breaking changes
- [UI] `SearchMode` now has a new value `AUTO`. If search mode set to `AUTO`, UI will determine online/offline mode automatically based on the device's network reachability.
- [CORE] `OfflineSearchEngine` functions `getTileRegions()`, `getGroupInfo()`, `loadTileRegion()`, `updateTilesGroup()`, `removeTilesGroup()` have been removed. Now you should use `TileStore` directly to work with offline data.
- [CORE] Signature of `EngineReadyCallback.onEngineReady()` has been changed. Now this function has no arguments.
- [CORE] Properties `OfflineSearchSettings.tilesDataset` and `OfflineSearchSettings.tilesVersion` and their corresponding Builder properties have been remove. Now dataset and version parameters can be specified during `TilesetDescriptor` creation.
- [CORE] `OfflineSearchEngine.addOflineRegion()` function and `AddRegionCallback` interface have been removed. Now you can use `TileStore` to manage offline data.

### New features
- [CORE] `DefaultLocationProvider` class now can be called from any thread.
- [CORE] A new property `OfflineSearchEngine.tileStore` is available. It returns `TileStore` object used for offline tiles management.

### Mapbox dependencies
- Common SDK `20.1.0`
- Telemetry SDK `8.1.0`