### PR TITLE
Search SDK v1.0.0-beta.23

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
     // Loader module is excluded just for custom library loader example.
     // Don't exclude it if you are good with a default loader.
-    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.22") {
+    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.23") {
         exclude group: "com.mapbox.common", module: "loader"
     }
     implementation ("com.mapbox.maps:android:10.0.0") {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
 
         <activity
             android:name=".CustomThemeActivity"
+            android:windowSoftInputMode="adjustNothing"
             android:theme="@style/CustomTheme"
             />
 

--- a/app/src/main/java/com/mapbox/search/sample/CustomThemeActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/CustomThemeActivity.kt
@@ -9,6 +9,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.mapbox.search.ui.view.SearchBottomSheetView
 import com.mapbox.search.ui.view.category.SearchCategoriesBottomSheetView
+import com.mapbox.search.ui.view.feedback.SearchFeedbackBottomSheetView
 import com.mapbox.search.ui.view.place.SearchPlaceBottomSheetView
 
 class CustomThemeActivity : AppCompatActivity() {
@@ -16,6 +17,7 @@ class CustomThemeActivity : AppCompatActivity() {
     private lateinit var searchBottomSheetView: SearchBottomSheetView
     private lateinit var searchPlaceView: SearchPlaceBottomSheetView
     private lateinit var searchCategoriesView: SearchCategoriesBottomSheetView
+    private lateinit var feedbackBottomSheetView: SearchFeedbackBottomSheetView
 
     private lateinit var cardsMediator: SearchViewBottomSheetsMediator
 
@@ -30,10 +32,14 @@ class CustomThemeActivity : AppCompatActivity() {
         searchPlaceView = findViewById(R.id.search_place_view)
         searchCategoriesView = findViewById(R.id.search_categories_view)
 
+        feedbackBottomSheetView = findViewById(R.id.search_feedback_view)
+        feedbackBottomSheetView.initialize(savedInstanceState)
+
         cardsMediator = SearchViewBottomSheetsMediator(
             searchBottomSheetView,
             searchPlaceView,
-            searchCategoriesView
+            searchCategoriesView,
+            feedbackBottomSheetView,
         )
 
         savedInstanceState?.let {

--- a/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
@@ -38,6 +38,7 @@ import com.mapbox.search.ui.view.SearchBottomSheetView
 import com.mapbox.search.ui.view.SearchMode
 import com.mapbox.search.ui.view.category.Category
 import com.mapbox.search.ui.view.category.SearchCategoriesBottomSheetView
+import com.mapbox.search.ui.view.feedback.SearchFeedbackBottomSheetView
 import com.mapbox.search.ui.view.place.SearchPlace
 import com.mapbox.search.ui.view.place.SearchPlaceBottomSheetView
 
@@ -46,6 +47,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var searchBottomSheetView: SearchBottomSheetView
     private lateinit var searchPlaceView: SearchPlaceBottomSheetView
     private lateinit var searchCategoriesView: SearchCategoriesBottomSheetView
+    private lateinit var feedbackBottomSheetView: SearchFeedbackBottomSheetView
 
     private lateinit var cardsMediator: SearchViewBottomSheetsMediator
 
@@ -72,12 +74,17 @@ class MainActivity : AppCompatActivity() {
         searchBottomSheetView.searchMode = SearchMode.AUTO
 
         searchPlaceView = findViewById(R.id.search_place_view)
+
         searchCategoriesView = findViewById(R.id.search_categories_view)
+
+        feedbackBottomSheetView = findViewById(R.id.search_feedback_view)
+        feedbackBottomSheetView.initialize(savedInstanceState)
 
         cardsMediator = SearchViewBottomSheetsMediator(
             searchBottomSheetView,
             searchPlaceView,
-            searchCategoriesView
+            searchCategoriesView,
+            feedbackBottomSheetView,
         )
 
         savedInstanceState?.let {
@@ -95,7 +102,6 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Process bottom sheets events
-        @Suppress("EmptyFunctionBlock")
         cardsMediator.addSearchBottomSheetsEventsListener(object : SearchViewBottomSheetsMediator.SearchBottomSheetsEventsListener {
             override fun onOpenPlaceBottomSheet(place: SearchPlace) {}
 

--- a/app/src/main/java/com/mapbox/search/sample/SearchDemoApplication.kt
+++ b/app/src/main/java/com/mapbox/search/sample/SearchDemoApplication.kt
@@ -1,10 +1,10 @@
 package com.mapbox.search.sample
 
 import android.app.Application
+import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.common.TileStore
 import com.mapbox.search.MapboxSearchSdk
 import com.mapbox.search.OfflineSearchSettings
-import com.mapbox.search.location.DefaultLocationProvider
 
 class SearchDemoApplication : Application() {
 
@@ -14,7 +14,7 @@ class SearchDemoApplication : Application() {
         MapboxSearchSdk.initialize(
             application = this,
             accessToken = BuildConfig.MAPBOX_API_TOKEN,
-            locationProvider = DefaultLocationProvider(this),
+            locationEngine = LocationEngineProvider.getBestLocationEngine(this),
             offlineSearchSettings = OfflineSearchSettings(tileStore = TileStore.create()),
         )
     }

--- a/app/src/main/java/com/mapbox/search/sample/SimpleUiSearchActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/SimpleUiSearchActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
+import com.mapbox.search.ResponseInfo
 import com.mapbox.search.record.HistoryRecord
 import com.mapbox.search.result.SearchResult
 import com.mapbox.search.result.SearchSuggestion
@@ -27,7 +28,7 @@ class SimpleUiSearchActivity : AppCompatActivity() {
         }
 
         searchResultsView.addSearchListener(object : SearchResultsView.SearchListener {
-            override fun onSearchResult(searchResult: SearchResult) {
+            override fun onSearchResult(searchResult: SearchResult, responseInfo: ResponseInfo) {
                 Toast.makeText(applicationContext, "Search result: $searchResult", Toast.LENGTH_SHORT).show()
             }
 
@@ -37,10 +38,14 @@ class SimpleUiSearchActivity : AppCompatActivity() {
                 }
             }
 
-            override fun onPopulateQueryClicked(suggestion: SearchSuggestion) {
+            override fun onPopulateQueryClicked(suggestion: SearchSuggestion, responseInfo: ResponseInfo) {
                 if (::searchView.isInitialized) {
                     searchView.setQuery(suggestion.name, true)
                 }
+            }
+
+            override fun onFeedbackClicked(responseInfo: ResponseInfo) {
+                // Not implemented
             }
         })
 

--- a/app/src/main/java/com/mapbox/search/sample/api/CategorySearchJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/CategorySearchJavaExampleActivity.java
@@ -43,7 +43,7 @@ public class CategorySearchJavaExampleActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        categorySearchEngine = MapboxSearchSdk.createCategorySearchEngine();
+        categorySearchEngine = MapboxSearchSdk.getCategorySearchEngine();
 
         final CategorySearchOptions options = new CategorySearchOptions.Builder()
             .limit(1)

--- a/app/src/main/java/com/mapbox/search/sample/api/CategorySearchKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/CategorySearchKotlinExampleActivity.kt
@@ -34,7 +34,7 @@ class CategorySearchKotlinExampleActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        categorySearchEngine = MapboxSearchSdk.createCategorySearchEngine()
+        categorySearchEngine = MapboxSearchSdk.getCategorySearchEngine()
 
         searchRequestTask = categorySearchEngine.search(
             "cafe",

--- a/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderJavaExample.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderJavaExample.java
@@ -2,8 +2,11 @@ package com.mapbox.search.sample.api;
 
 import android.os.Bundle;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+
 import com.mapbox.geojson.Point;
 import com.mapbox.search.AsyncOperationTask;
 import com.mapbox.search.CompletionCallback;
@@ -28,7 +31,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import androidx.annotation.NonNull;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;
@@ -81,7 +83,7 @@ public class CustomIndexableDataProviderJavaExample extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        searchEngine = MapboxSearchSdk.createSearchEngine();
+        searchEngine = MapboxSearchSdk.getSearchEngine();
 
         Log.i("SearchApiExample", "Start CustomDataProvider registering...");
         registerProviderTask = MapboxSearchSdk.getServiceProvider().globalDataProvidersRegistry().register(
@@ -267,6 +269,9 @@ public class CustomIndexableDataProviderJavaExample extends AppCompatActivity {
             @NonNull Executor executor,
             @NonNull CompletionCallback<Unit> callback
         ) {
+            for (IndexableDataProviderEngineLayer layer : dataProviderEngineLayers) {
+                layer.add(record);
+            }
             records.put(record.getId(), record);
             executor.execute(() -> callback.onComplete(Unit.INSTANCE));
             return CompletedAsyncOperationTask.getInstance();
@@ -285,7 +290,10 @@ public class CustomIndexableDataProviderJavaExample extends AppCompatActivity {
             @NonNull Executor executor,
             @NonNull CompletionCallback<Unit> callback
         ) {
-            for (R record: records) {
+            for (IndexableDataProviderEngineLayer layer : dataProviderEngineLayers) {
+                layer.addAll(records);
+            }
+            for (R record : records) {
                 this.records.put(record.getId(), record);
             }
             executor.execute(() -> callback.onComplete(Unit.INSTANCE));
@@ -305,6 +313,9 @@ public class CustomIndexableDataProviderJavaExample extends AppCompatActivity {
             @NonNull Executor executor,
             @NonNull CompletionCallback<Unit> callback
         ) {
+            for (IndexableDataProviderEngineLayer layer : dataProviderEngineLayers) {
+                layer.update(record);
+            }
             records.put(record.getId(), record);
             executor.execute(() -> callback.onComplete(Unit.INSTANCE));
             return CompletedAsyncOperationTask.getInstance();
@@ -323,6 +334,9 @@ public class CustomIndexableDataProviderJavaExample extends AppCompatActivity {
             @NonNull Executor executor,
             @NonNull CompletionCallback<Boolean> callback
         ) {
+            for (IndexableDataProviderEngineLayer layer : dataProviderEngineLayers) {
+                layer.remove(id);
+            }
             boolean isRemoved = records.remove(id) != null;
             executor.execute(() -> callback.onComplete(isRemoved));
             return CompletedAsyncOperationTask.getInstance();
@@ -337,6 +351,9 @@ public class CustomIndexableDataProviderJavaExample extends AppCompatActivity {
         @NonNull
         @Override
         public AsyncOperationTask clear(@NonNull Executor executor, @NonNull CompletionCallback<Unit> callback) {
+            for (IndexableDataProviderEngineLayer layer : dataProviderEngineLayers) {
+                layer.clear();
+            }
             records.clear();
             executor.execute(() -> callback.onComplete(Unit.INSTANCE));
             return CompletedAsyncOperationTask.getInstance();

--- a/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderKotlinExample.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/CustomIndexableDataProviderKotlinExample.kt
@@ -73,7 +73,7 @@ class CustomIndexableDataProviderKotlinExample : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        searchEngine = MapboxSearchSdk.createSearchEngine()
+        searchEngine = MapboxSearchSdk.getSearchEngine()
 
         Log.i("SearchApiExample", "Start CustomDataProvider registering...")
         registerProviderTask = MapboxSearchSdk.serviceProvider.globalDataProvidersRegistry().register(
@@ -200,6 +200,9 @@ class CustomIndexableDataProviderKotlinExample : AppCompatActivity() {
         }
 
         override fun add(record: R, executor: Executor, callback: CompletionCallback<Unit>): AsyncOperationTask {
+            dataProviderEngineLayers.forEach {
+                it.add(record)
+            }
             records[record.id] = record
             executor.execute {
                 callback.onComplete(Unit)
@@ -212,6 +215,9 @@ class CustomIndexableDataProviderKotlinExample : AppCompatActivity() {
             executor: Executor,
             callback: CompletionCallback<Unit>
         ): AsyncOperationTask {
+            dataProviderEngineLayers.forEach {
+                it.addAll(records)
+            }
             for (record in records) {
                 this.records[record.id] = record
             }
@@ -222,6 +228,9 @@ class CustomIndexableDataProviderKotlinExample : AppCompatActivity() {
         }
 
         override fun update(record: R, executor: Executor, callback: CompletionCallback<Unit>): AsyncOperationTask {
+            dataProviderEngineLayers.forEach {
+                it.update(record)
+            }
             records[record.id] = record
             executor.execute {
                 callback.onComplete(Unit)
@@ -230,6 +239,9 @@ class CustomIndexableDataProviderKotlinExample : AppCompatActivity() {
         }
 
         override fun remove(id: String, executor: Executor, callback: CompletionCallback<Boolean>): AsyncOperationTask {
+            dataProviderEngineLayers.forEach {
+                it.remove(id)
+            }
             val isRemoved = records.remove(id) != null
             executor.execute {
                 callback.onComplete(isRemoved)
@@ -238,6 +250,9 @@ class CustomIndexableDataProviderKotlinExample : AppCompatActivity() {
         }
 
         override fun clear(executor: Executor, callback: CompletionCallback<Unit>): AsyncOperationTask {
+            dataProviderEngineLayers.forEach {
+                it.clear()
+            }
             records.clear()
             executor.execute {
                 callback.onComplete(Unit)

--- a/app/src/main/java/com/mapbox/search/sample/api/ForwardGeocodingBatchResolvingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/ForwardGeocodingBatchResolvingJavaExampleActivity.java
@@ -69,7 +69,7 @@ public class ForwardGeocodingBatchResolvingJavaExampleActivity extends AppCompat
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        searchEngine = MapboxSearchSdk.createSearchEngine();
+        searchEngine = MapboxSearchSdk.getSearchEngine();
 
         final SearchOptions options = new SearchOptions.Builder()
             .build();

--- a/app/src/main/java/com/mapbox/search/sample/api/ForwardGeocodingBatchResolvingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/ForwardGeocodingBatchResolvingKotlinExampleActivity.kt
@@ -60,7 +60,7 @@ class ForwardGeocodingBatchResolvingKotlinExampleActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        searchEngine = MapboxSearchSdk.createSearchEngine()
+        searchEngine = MapboxSearchSdk.getSearchEngine()
 
         searchRequestTask = searchEngine.search(
             "Paris Eiffel Tower",

--- a/app/src/main/java/com/mapbox/search/sample/api/ForwardGeocodingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/ForwardGeocodingJavaExampleActivity.java
@@ -55,7 +55,7 @@ public class ForwardGeocodingJavaExampleActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        searchEngine = MapboxSearchSdk.createSearchEngine();
+        searchEngine = MapboxSearchSdk.getSearchEngine();
 
         final SearchOptions options = new SearchOptions.Builder()
             .limit(5)

--- a/app/src/main/java/com/mapbox/search/sample/api/ForwardGeocodingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/ForwardGeocodingKotlinExampleActivity.kt
@@ -51,7 +51,7 @@ class ForwardGeocodingKotlinExampleActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        searchEngine = MapboxSearchSdk.createSearchEngine()
+        searchEngine = MapboxSearchSdk.getSearchEngine()
 
         searchRequestTask = searchEngine.search(
             "Paris Eiffel Tower",

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingJavaExampleActivity.java
@@ -22,6 +22,7 @@ import com.mapbox.search.SearchRequestTask;
 import com.mapbox.search.result.SearchResult;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class OfflineReverseGeocodingJavaExampleActivity extends AppCompatActivity {
@@ -67,9 +68,7 @@ public class OfflineReverseGeocodingJavaExampleActivity extends AppCompatActivit
 
         final Point dcLocation = Point.fromLngLat(-77.0339911055176, 38.899920004207516);
 
-        final List<TilesetDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(searchEngine.createBoundariesTilesetDescriptor());
-        descriptors.add(searchEngine.createTilesetDescriptor());
+        final List<TilesetDescriptor> descriptors = Collections.singletonList(searchEngine.createTilesetDescriptor());
 
         final TileRegionLoadOptions tileRegionLoadOptions = new TileRegionLoadOptions.Builder()
             .descriptors(descriptors)

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineReverseGeocodingKotlinExampleActivity.kt
@@ -51,10 +51,7 @@ class OfflineReverseGeocodingKotlinExampleActivity : Activity() {
 
         val dcLocation = Point.fromLngLat(-77.0339911055176, 38.899920004207516)
 
-        val descriptors = mutableListOf(
-            searchEngine.createBoundariesTilesetDescriptor(),
-            searchEngine.createTilesetDescriptor()
-        )
+        val descriptors = listOf(searchEngine.createTilesetDescriptor())
 
         val tileRegionLoadOptions = TileRegionLoadOptions.Builder()
             .descriptors(descriptors)

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
@@ -23,6 +23,7 @@ import com.mapbox.search.result.SearchResult;
 import com.mapbox.search.result.SearchSuggestion;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class OfflineSearchJavaExampleActivity extends AppCompatActivity {
@@ -83,9 +84,7 @@ public class OfflineSearchJavaExampleActivity extends AppCompatActivity {
 
         final Point dcLocation = Point.fromLngLat(-77.0339911055176, 38.899920004207516);
 
-        final List<TilesetDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(searchEngine.createBoundariesTilesetDescriptor());
-        descriptors.add(searchEngine.createTilesetDescriptor());
+        final List<TilesetDescriptor> descriptors = Collections.singletonList(searchEngine.createTilesetDescriptor());
 
         final TileRegionLoadOptions tileRegionLoadOptions = new TileRegionLoadOptions.Builder()
             .descriptors(descriptors)

--- a/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
@@ -73,10 +73,7 @@ class OfflineSearchKotlinExampleActivity : Activity() {
 
         val dcLocation = Point.fromLngLat(-77.0339911055176, 38.899920004207516)
 
-        val descriptors = mutableListOf(
-            searchEngine.createBoundariesTilesetDescriptor(),
-            searchEngine.createTilesetDescriptor()
-        )
+        val descriptors = listOf(searchEngine.createTilesetDescriptor())
 
         val tileRegionLoadOptions = TileRegionLoadOptions.Builder()
             .descriptors(descriptors)

--- a/app/src/main/java/com/mapbox/search/sample/api/ReverseGeocodingJavaExampleActivity.java
+++ b/app/src/main/java/com/mapbox/search/sample/api/ReverseGeocodingJavaExampleActivity.java
@@ -44,7 +44,7 @@ public class ReverseGeocodingJavaExampleActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        reverseGeocoding = MapboxSearchSdk.createReverseGeocodingSearchEngine();
+        reverseGeocoding = MapboxSearchSdk.getReverseGeocodingSearchEngine();
 
         final ReverseGeoOptions options = new ReverseGeoOptions.Builder(Point.fromLngLat(2.294434, 48.858349))
             .limit(1)

--- a/app/src/main/java/com/mapbox/search/sample/api/ReverseGeocodingKotlinExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/api/ReverseGeocodingKotlinExampleActivity.kt
@@ -35,7 +35,7 @@ class ReverseGeocodingKotlinExampleActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        reverseGeocoding = MapboxSearchSdk.createReverseGeocodingSearchEngine()
+        reverseGeocoding = MapboxSearchSdk.getReverseGeocodingSearchEngine()
 
         val options = ReverseGeoOptions(
             center = Point.fromLngLat(2.294434, 48.858349),

--- a/app/src/main/java/com/mapbox/search/sample/maps/MapsIntegrationExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/maps/MapsIntegrationExampleActivity.kt
@@ -37,6 +37,7 @@ import com.mapbox.search.ui.view.SearchBottomSheetView
 import com.mapbox.search.ui.view.category.Category
 import com.mapbox.search.ui.view.category.SearchCategoriesBottomSheetView
 import com.mapbox.search.ui.view.category.SearchCategoriesBottomSheetView.CategoryLoadingStateListener
+import com.mapbox.search.ui.view.feedback.SearchFeedbackBottomSheetView
 import com.mapbox.search.ui.view.place.SearchPlace
 import com.mapbox.search.ui.view.place.SearchPlaceBottomSheetView
 
@@ -48,6 +49,7 @@ class MapsIntegrationExampleActivity : AppCompatActivity() {
     private lateinit var searchBottomSheetView: SearchBottomSheetView
     private lateinit var searchPlaceView: SearchPlaceBottomSheetView
     private lateinit var searchCategoriesView: SearchCategoriesBottomSheetView
+    private lateinit var feedbackBottomSheetView: SearchFeedbackBottomSheetView
 
     private lateinit var cardsMediator: SearchViewBottomSheetsMediator
 
@@ -94,10 +96,14 @@ class MapsIntegrationExampleActivity : AppCompatActivity() {
 
         searchCategoriesView = findViewById(R.id.search_categories_view)
 
+        feedbackBottomSheetView = findViewById(R.id.search_feedback_view)
+        feedbackBottomSheetView.initialize(savedInstanceState)
+
         cardsMediator = SearchViewBottomSheetsMediator(
             searchBottomSheetView,
             searchPlaceView,
-            searchCategoriesView
+            searchCategoriesView,
+            feedbackBottomSheetView,
         )
 
         savedInstanceState?.let {

--- a/app/src/main/res/layout/activity_custom_theme.xml
+++ b/app/src/main/res/layout/activity_custom_theme.xml
@@ -3,7 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/windowBackground"
     >
 
     <com.mapbox.search.ui.view.SearchBottomSheetView
@@ -28,6 +27,14 @@
         android:layout_height="match_parent"
         android:layout_gravity="center_horizontal"
         android:elevation="8dp"
+        />
+
+    <com.mapbox.search.ui.view.feedback.SearchFeedbackBottomSheetView
+        android:id="@+id/search_feedback_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_horizontal"
+        android:elevation="@dimen/search_card_elevation"
         />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/windowBackground"
     tools:context=".MainActivity"
+    tools:ignore="MergeRootFrame"
     >
 
     <androidx.appcompat.widget.Toolbar
@@ -47,5 +47,12 @@
             android:elevation="@dimen/search_card_elevation"
             />
 
+        <com.mapbox.search.ui.view.feedback.SearchFeedbackBottomSheetView
+            android:id="@+id/search_feedback_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_horizontal"
+            android:elevation="@dimen/search_card_elevation"
+            />
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/activity_maps_integration.xml
+++ b/app/src/main/res/layout/activity_maps_integration.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     >
 
     <com.mapbox.maps.MapView
@@ -42,5 +42,13 @@
             android:elevation="8dp"
             />
 
+        <com.mapbox.search.ui.view.feedback.SearchFeedbackBottomSheetView
+            android:id="@+id/search_feedback_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_horizontal"
+            android:elevation="@dimen/search_card_elevation"
+            />
+
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
-</FrameLayout>
+</merge>

--- a/app/src/main/res/layout/activity_simple_ui.xml
+++ b/app/src/main/res/layout/activity_simple_ui.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/windowBackground"
     android:theme="@style/SimpleUiTheme"
     tools:context=".SimpleUiSearchActivity"
     >
@@ -22,8 +21,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?actionBarSize"
-        android:paddingTop="22dp"
         android:clipToPadding="false"
+        android:paddingTop="22dp"
         />
 
-</FrameLayout>
+</merge>


### PR DESCRIPTION
## 1.0.0-beta.23

### Breaking changes
- [CORE] Signature of `OfflineSearchEngine.select(SearchSuggestion, Executor, SearchSelectionCallback): SearchRequestTask` function has been changed, now it also accepts `SelectOptions`.
- [CORE] Functions `MapboxSearchSdk.createCategorySearchEngine()`, `MapboxSearchSdk.createReverseGeocodingSearchEngine()` and `MapboxSearchSdk.createSearchEngine()` have been replaced with `MapboxSearchSdk.getCategorySearchEngine()`, `MapboxSearchSdk.getReverseGeocodingSearchEngine()` and `MapboxSearchSdk.getSearchEngine()` functions accordingly. Now SDK consumers can access only single instance of each search engine.
- [CORE] `MapboxSearchSdk.initialize()` now accepts `com.mapbox.android.core.location.LocationEngine` instead of `com.mapbox.search.location.LocationProvider`, argument name has also been changed from `locationProvider` to `locationEngine`. `com.mapbox.search.location.LocationProvider`, `com.mapbox.search.location.DefaultLocationProvider`, `com.mapbox.search.location.PointLocationProvider` have been removed. Now you can use `com.mapbox.android.core.location.LocationEngineProvider.getBestLocationEngine(Context)` to get a default implementation of `LocationEngine`.
- [CORE] Function `com.mapbox.search.ServiceProvider.locationProvider()` has been removed, now `ServiceProvider.locationEngine()` is available which returns instance of `com.mapbox.android.core.location.LocationEngine`.
- [CORE] `OfflineSearchEngine.createBoundariesTilesetDescriptor()` has been renamed to `createPlacesTilesetDescriptor()`.
- [UI] `SearchPlace` has a new property `feedback`, constructor and `copy` function signature have been changed.
- [UI] Now `SearchPlace.createFromSearchResult()` requires `ResponseInfo` as an additional argument.
- [UI] `SearchBottomSheetView.OnSearchResultClickListener.onSearchResultClick()` and `SearchCategoriesBottomSheetView.OnSearchResultClickListener.onSearchResultClick()` receive `ResponseInfo` as an additional argument.
- [UI] `SearchResultsView.SearchListener`'s functions `onSearchResult()` and `onPopulateQueryClicked()` now receive `ResponseInfo` as an additional argument.

### New features
- [CORE] `IndexableDataProviderEngineLayer` class now can be called from any thread.
- [CORE] Now selected search suggestions from `OfflineSarchEngine` are added to `HistoryDataProvider` by default. You can manage this behavior by passing custom `SelectOptions` to `select()` function.
- [CORE] New functions `IndexableDataProviderEngineLayer.removeAll()` and `IndexableDataProviderEngineLayer.executeBatchUpdate()` and new interface `IndexableDataProviderEngineLayer.BatchUpdateOperation` have been introduced. Now user can remove several records in one go and also specify several operations that should be executed atomically for a given engine layer.
- [CORE] Now `OfflineSearchEngine` has a new functions for selecting preferable tileset - `selectTileset()`.
- [CORE] Also, `OfflineSearchEngine` can notify users of index change events. Add a listener via `addOnIndexChangeListener()` to get these events.
- [UI] Now `SearchPlaceBottomSheetView` class notifies users about adding specific `SearchPlace` to favorites via `SearchPlaceBottomSheetView.OnSearchPlaceAddedToFavoritesListener`.
- [UI] `SearchPlaceBottomSheetView` has a new `Feedback` button that enables users to report issues and send feedback on search quality. With this functionality also come `OnFeedbackClickListener` and functions to add/remove feedback listeners. Customers have to use `SearchFeedbackBottomSheetView` or implement feedback UI on their own.
- [UI] Now a new view `SearchFeedbackBottomSheetView` which implements feedback workflow is available. Customers can add their own listener via `addOnFeedbackSubmitClickListener()` to hook feedback sending to define their own behavior.
- [UI] Now `SearchBottomSheetView` has new interfaces `OnFeedbackClickListener`, and `OnFeedbackSubmitClickListener`. Customers can add their own listeners via `addOnFeedbackClickListener`, and `addOnFeedbackSubmitClickListener()` to hook feedback sending and define custom behavior.

### Bug fixes
- [CORE] Fixed bug related to unexpected cancellation of scheduled `SearchEngine` request when another search request was fired from `CategorySearchEngine` or from another `SearchEngine`.
- [CORE] Fixed bug in `HistoryDataProvider` when records weren't removed from `IndexableDataProviderEngineLayer` during the trimming of obsolete records.
- [UI] Fixed several bugs related to state restoration, keyboard showing and UI lagginess. 

### Mapbox dependencies
- Search Native SDK `0.44.1`
- Common SDK `20.1.1`
- Telemetry SDK `8.1.0`