### PR TITLE
Search SDK for Android v1.0.0-beta.24

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,15 +51,15 @@ dependencies {
 
     // Loader module is excluded just for custom library loader example.
     // Don't exclude it if you are good with a default loader.
-    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.23") {
+    implementation ("com.mapbox.search:mapbox-search-android-ui:1.0.0-beta.24") {
         exclude group: "com.mapbox.common", module: "loader"
     }
-    implementation ("com.mapbox.maps:android:10.0.0") {
+    implementation ("com.mapbox.maps:android:10.2.0") {
         exclude group: "com.mapbox.common", module: "loader"
     }
 
     // Needed just for custom library loader example.
-    compileOnly "com.mapbox.base:annotations:0.5.0"
+    compileOnly "com.mapbox.base:annotations:0.6.0"
     kapt "com.mapbox.base:annotations-processor:0.5.0"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/java/com/mapbox/search/sample/CustomThemeActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/CustomThemeActivity.kt
@@ -7,6 +7,8 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import com.mapbox.search.ui.view.CommonSearchViewConfiguration
+import com.mapbox.search.ui.view.DistanceUnitType
 import com.mapbox.search.ui.view.SearchBottomSheetView
 import com.mapbox.search.ui.view.category.SearchCategoriesBottomSheetView
 import com.mapbox.search.ui.view.feedback.SearchFeedbackBottomSheetView
@@ -30,7 +32,10 @@ class CustomThemeActivity : AppCompatActivity() {
         searchBottomSheetView.initializeSearch(savedInstanceState, SearchBottomSheetView.Configuration())
 
         searchPlaceView = findViewById(R.id.search_place_view)
+        searchPlaceView.initialize(CommonSearchViewConfiguration(DistanceUnitType.IMPERIAL))
+
         searchCategoriesView = findViewById(R.id.search_categories_view)
+        searchCategoriesView.initialize(CommonSearchViewConfiguration(DistanceUnitType.IMPERIAL))
 
         feedbackBottomSheetView = findViewById(R.id.search_feedback_view)
         feedbackBottomSheetView.initialize(savedInstanceState)

--- a/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/MainActivity.kt
@@ -34,6 +34,8 @@ import com.mapbox.search.sample.api.OfflineSearchKotlinExampleActivity
 import com.mapbox.search.sample.api.ReverseGeocodingJavaExampleActivity
 import com.mapbox.search.sample.api.ReverseGeocodingKotlinExampleActivity
 import com.mapbox.search.sample.maps.MapsIntegrationExampleActivity
+import com.mapbox.search.ui.view.CommonSearchViewConfiguration
+import com.mapbox.search.ui.view.DistanceUnitType
 import com.mapbox.search.ui.view.SearchBottomSheetView
 import com.mapbox.search.ui.view.SearchMode
 import com.mapbox.search.ui.view.category.Category
@@ -74,8 +76,10 @@ class MainActivity : AppCompatActivity() {
         searchBottomSheetView.searchMode = SearchMode.AUTO
 
         searchPlaceView = findViewById(R.id.search_place_view)
+        searchPlaceView.initialize(CommonSearchViewConfiguration(DistanceUnitType.IMPERIAL))
 
         searchCategoriesView = findViewById(R.id.search_categories_view)
+        searchCategoriesView.initialize(CommonSearchViewConfiguration(DistanceUnitType.IMPERIAL))
 
         feedbackBottomSheetView = findViewById(R.id.search_feedback_view)
         feedbackBottomSheetView.initialize(savedInstanceState)

--- a/app/src/main/java/com/mapbox/search/sample/SimpleUiSearchActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/SimpleUiSearchActivity.kt
@@ -12,6 +12,8 @@ import com.mapbox.search.ResponseInfo
 import com.mapbox.search.record.HistoryRecord
 import com.mapbox.search.result.SearchResult
 import com.mapbox.search.result.SearchSuggestion
+import com.mapbox.search.ui.view.CommonSearchViewConfiguration
+import com.mapbox.search.ui.view.DistanceUnitType
 import com.mapbox.search.ui.view.SearchResultsView
 
 class SimpleUiSearchActivity : AppCompatActivity() {
@@ -24,6 +26,7 @@ class SimpleUiSearchActivity : AppCompatActivity() {
         setContentView(R.layout.activity_simple_ui)
 
         searchResultsView = findViewById<SearchResultsView>(R.id.search_results_view).apply {
+            initialize(CommonSearchViewConfiguration(DistanceUnitType.IMPERIAL))
             isVisible = false
         }
 

--- a/app/src/main/java/com/mapbox/search/sample/maps/MapsIntegrationExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/search/sample/maps/MapsIntegrationExampleActivity.kt
@@ -33,6 +33,8 @@ import com.mapbox.search.result.SearchResult
 import com.mapbox.search.sample.R
 import com.mapbox.search.sample.SearchViewBottomSheetsMediator
 import com.mapbox.search.sample.SearchViewBottomSheetsMediator.SearchBottomSheetsEventsListener
+import com.mapbox.search.ui.view.CommonSearchViewConfiguration
+import com.mapbox.search.ui.view.DistanceUnitType
 import com.mapbox.search.ui.view.SearchBottomSheetView
 import com.mapbox.search.ui.view.category.Category
 import com.mapbox.search.ui.view.category.SearchCategoriesBottomSheetView
@@ -89,12 +91,15 @@ class MapsIntegrationExampleActivity : AppCompatActivity() {
         searchBottomSheetView.initializeSearch(savedInstanceState, SearchBottomSheetView.Configuration())
 
         searchPlaceView = findViewById<SearchPlaceBottomSheetView>(R.id.search_place_view).apply {
+            initialize(CommonSearchViewConfiguration(DistanceUnitType.IMPERIAL))
+
             isNavigateButtonVisible = false
             isShareButtonVisible = false
             isFavoriteButtonVisible = false
         }
 
         searchCategoriesView = findViewById(R.id.search_categories_view)
+        searchCategoriesView.initialize(CommonSearchViewConfiguration(DistanceUnitType.IMPERIAL))
 
         feedbackBottomSheetView = findViewById(R.id.search_feedback_view)
         feedbackBottomSheetView.initialize(savedInstanceState)


### PR DESCRIPTION
## 1.0.0-beta.24

### Breaking changes
- [UI] Now initialization methods `SearchPlaceBottomSheetView.initialize()`, `SearchCategoriesBottomSheetView.initialize()`, `SearchResultsView.initialize()` have to be called in order to make these views work properly.

### New features
- [UI] Now you can provide distance unit type (imperial or metric) used for views visual information via initialization methods of the views: `SearchBottomSheetView.initializeSearch()`, `SearchPlaceBottomSheetView.initialize()`, `SearchCategoriesBottomSheetView.initialize()`, `SearchResultsView.initialize()`.

### Bug fixes
- [UI] Fixed a bug with uninitialized properties in created from `SearchBottomSheetView` favorite record.

### Mapbox dependencies
- Search Native SDK `0.46.1`
- Common SDK `21.0.1`
- Telemetry SDK `8.1.0`